### PR TITLE
Changes special characters åöä to be compatible with maven

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.datasource.password=${DB_PASSWORD}
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-#Hibernate läser bara vårt schema, ändra till validate sen.
+#Hibernate reads only our schema, change to validate later on
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
application.properties file fail during mvn clean and compile, due to special characters (in this case ä). This PR translate comment into english and thus eliminates any special character and makes the mvn compile work again.