### PR TITLE
Feat/medical record policy

### DIFF
--- a/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
@@ -55,7 +55,20 @@ public class MedicalRecordPolicy {
         }
     }
 
+    public void canUpdateStatus(User user, MedicalRecord record, RecordStatus newStatus) {
+        if (record.getStatus().isFinal())
+            throw new BusinessRuleException("Stängda ärenden kan inte uppdateras");
 
+        switch (user.getRole()) {
+            case OWNER ->
+                    throw new ForbiddenException("Ägare får inte ändra status på ärenden");
+            case VET -> {
+                if (!sameClinic(user, record))
+                    throw new ForbiddenException("Du har inte tillgång till ärenden på en annan klinik");
+            }
+            case ADMIN -> {}
+        }
+    }
 
     public void canAssignVet(User user, MedicalRecord record, User vetToAssign) {
         switch (user.getRole()) {


### PR DESCRIPTION
Closes #21 

canView()         → OWNER sees own records, VET sees clinic records, ADMIN sees all
canCreate()       → OWNER creates for own pets, VET creates for own clinic
canUpdate()       → blocks closed records, OWNER/VET restricted by ownership/clinic
canUpdateStatus() → OWNER blocked, VET restricted to own clinic
canAssignVet()    → OWNER blocked, VET validates both user and assignee clinic match
canClose()        → OWNER blocked, VET restricted to own clinic
canViewClinic()   → OWNER blocked, VET restricted to own clinic
