### PR TITLE
test: add unit tests for PetEntity

### DIFF
--- a/src/test/java/org/example/vet1177/entities/PetEntityTest.java
+++ b/src/test/java/org/example/vet1177/entities/PetEntityTest.java
@@ -27,7 +27,7 @@ public class PetEntityTest {
     }
 
     @Test
-    void setSpeices_shouldStoreAndReturnCorrectValue(){
+    void setSpecies_shouldStoreAndReturnCorrectValue(){
         pet.setSpecies("hund");
 
         assertThat(pet.getSpecies()).isEqualTo("hund");
@@ -35,14 +35,14 @@ public class PetEntityTest {
 
 
     @Test
-    void setBread_shouldStoreAndReturnCorrectValue(){
+    void setBreed_shouldStoreAndReturnCorrectValue(){
         pet.setBreed("Labrador");
 
         assertThat(pet.getBreed()).isEqualTo("Labrador");
     }
 
     @Test
-    void setDateOfBirth_shouldStorAndReturnCorrectValue(){
+    void setDateOfBirth_shouldStoreAndReturnCorrectValue(){
         LocalDate dob = LocalDate.of(2025, 12, 21);
         pet.setDateOfBirth(dob);
 
@@ -50,7 +50,7 @@ public class PetEntityTest {
     }
 
     @Test
-    void setWeigthKg_shouldStoreAndReturnCorrectValue(){
+    void setWeightKg_shouldStoreAndReturnCorrectValue(){
         BigDecimal weight = new BigDecimal("13.50");
         pet.setWeightKg(weight);
 


### PR DESCRIPTION
Closes #142

Täcker:

- Getters och setters
- Konstruktor med alla fält
- onCreate() sätter createdAt och updatedAt
- onUpdate() uppdaterar updatedAt utan att röra createdAt
- Standardvärden är null innan persist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the Pet entity covering getters/setters, full-constructor behavior (including nullable breed), default pre-persistence state, and lifecycle timestamp management (creation and update timestamps). Tests verify numeric weight handling and owner association, ensuring timestamps are set on create and updated on subsequent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->