### PR TITLE
test: add unit tests for PetPolicy

### DIFF
--- a/src/test/java/org/example/vet1177/policy/PetPolicyTest.java
+++ b/src/test/java/org/example/vet1177/policy/PetPolicyTest.java
@@ -144,4 +144,27 @@ class PetPolicyTest {
         assertThat(policy.canDelete(owner, pet)).isFalse();
     }
 
+    //canUpdate
+    @Test
+    void canUpdate_ownerOfPet_shouldReturnTrue() {
+        assertThat(policy.canUpdate(owner, pet)).isTrue();
+    }
+
+    @Test
+    void canUpdate_ownerOfOtherPet_shouldReturnFalse() {
+        assertThat(policy.canUpdate(otherOwner, pet)).isFalse();
+    }
+
+    @Test
+    void canUpdate_vet_shouldReturnFalse() {
+        assertThat(policy.canUpdate(vet, pet)).isFalse();
+    }
+
+    @Test
+    void canUpdate_ownerWithNullPetOwner_shouldReturnFalse() {
+        pet.setOwner(null);
+
+        assertThat(policy.canUpdate(owner, pet)).isFalse();
+    }
+
 }


### PR DESCRIPTION
Closes #143

Täcker canCreate, canView, canViewOwnerPets, canUpdate och canDelete för rollerna ADMIN, OWNER och VET, inklusive edge cases som null-ägare och åtkomst till andras djur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for pet access controls, verifying who can create, view, update, delete, and list owner pets across Admin, Owner, and Vet roles — including scenarios where a pet has no owner — to ensure consistent permission enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->