### PR TITLE
Test: add unit tests for VetResponse mapping

### DIFF
--- a/src/test/java/org/example/vet1177/dto/response/vet/VetResponseTest.java
+++ b/src/test/java/org/example/vet1177/dto/response/vet/VetResponseTest.java
@@ -83,7 +83,7 @@ class VetResponseTest {
         assertFalse(response.isActive());
     }
 
-// Helper methods (gör testen renare och mer professionella)
+// Helper methods
 
     private void setUserId(User user, UUID id) throws Exception {
         Field field = User.class.getDeclaredField("id");

--- a/src/test/java/org/example/vet1177/dto/response/vet/VetResponseTest.java
+++ b/src/test/java/org/example/vet1177/dto/response/vet/VetResponseTest.java
@@ -1,0 +1,86 @@
+package org.example.vet1177.dto.response.vet;
+
+import org.example.vet1177.entities.*;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VetResponseTest {
+
+    @Test
+    void should_map_all_fields_correctly_when_clinic_exists() throws Exception {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+
+        Clinic clinic = new Clinic();
+        clinic.setName("Happy Pets Clinic");
+
+        User user = new User();
+        user.setName("Dr. Smith");
+        user.setEmail("dr.smith@test.com");
+        user.setActive(true);
+        user.setClinic(clinic);
+
+        // Set User ID
+        Field idField = User.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(user, userId);
+
+        Vet vet = new Vet();
+        vet.setUser(user);
+        vet.setLicenseId("LIC123");
+        vet.setSpecialization("Surgery");
+        vet.setBookingInfo("Available weekdays");
+
+        // SÄTT userId PÅ Vet
+        Field vetUserIdField = Vet.class.getDeclaredField("userId");
+        vetUserIdField.setAccessible(true);
+        vetUserIdField.set(vet, userId);
+
+        // Act
+        VetResponse response = VetResponse.from(vet);
+
+        // Assert
+        assertEquals(userId, response.userId());
+        assertEquals("Dr. Smith", response.name());
+        assertEquals("dr.smith@test.com", response.email());
+        assertEquals("LIC123", response.licenseId());
+        assertEquals("Surgery", response.specialization());
+        assertEquals("Available weekdays", response.bookingInfo());
+        assertEquals("Happy Pets Clinic", response.clinicName());
+        assertTrue(response.isActive());
+    }
+
+    @Test
+    void should_set_clinicName_to_null_when_clinic_is_null() throws Exception {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+
+        User user = new User();
+        user.setName("Dr. No Clinic");
+        user.setEmail("noclinic@test.com");
+        user.setActive(false);
+        user.setClinic(null);
+
+        // Reflection, i tester måste man simulera JPA, @MapsId styr ID automatiskt vet.userId = user.id
+        Field idField = User.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(user, userId);
+
+        Vet vet = new Vet();
+        vet.setUser(user);
+        vet.setLicenseId("LIC999");
+        vet.setSpecialization("Dentistry");
+        vet.setBookingInfo("Weekends");
+
+        // Act
+        VetResponse response = VetResponse.from(vet);
+
+        // Assert
+        assertNull(response.clinicName());
+        assertFalse(response.isActive());
+    }
+}

--- a/src/test/java/org/example/vet1177/dto/response/vet/VetResponseTest.java
+++ b/src/test/java/org/example/vet1177/dto/response/vet/VetResponseTest.java
@@ -24,10 +24,7 @@ class VetResponseTest {
         user.setActive(true);
         user.setClinic(clinic);
 
-        // Set User ID
-        Field idField = User.class.getDeclaredField("id");
-        idField.setAccessible(true);
-        idField.set(user, userId);
+        setUserId(user, userId);
 
         Vet vet = new Vet();
         vet.setUser(user);
@@ -35,10 +32,7 @@ class VetResponseTest {
         vet.setSpecialization("Surgery");
         vet.setBookingInfo("Available weekdays");
 
-        // SÄTT userId PÅ Vet
-        Field vetUserIdField = Vet.class.getDeclaredField("userId");
-        vetUserIdField.setAccessible(true);
-        vetUserIdField.set(vet, userId);
+        setVetUserId(vet, userId);
 
         // Act
         VetResponse response = VetResponse.from(vet);
@@ -65,10 +59,7 @@ class VetResponseTest {
         user.setActive(false);
         user.setClinic(null);
 
-        // Reflection, i tester måste man simulera JPA, @MapsId styr ID automatiskt vet.userId = user.id
-        Field idField = User.class.getDeclaredField("id");
-        idField.setAccessible(true);
-        idField.set(user, userId);
+        setUserId(user, userId);
 
         Vet vet = new Vet();
         vet.setUser(user);
@@ -76,11 +67,34 @@ class VetResponseTest {
         vet.setSpecialization("Dentistry");
         vet.setBookingInfo("Weekends");
 
+        setVetUserId(vet, userId);
+
         // Act
         VetResponse response = VetResponse.from(vet);
 
         // Assert
+        assertEquals(userId, response.userId());
+        assertEquals("Dr. No Clinic", response.name());
+        assertEquals("noclinic@test.com", response.email());
+        assertEquals("LIC999", response.licenseId());
+        assertEquals("Dentistry", response.specialization());
+        assertEquals("Weekends", response.bookingInfo());
         assertNull(response.clinicName());
         assertFalse(response.isActive());
     }
+
+// Helper methods (gör testen renare och mer professionella)
+
+    private void setUserId(User user, UUID id) throws Exception {
+        Field field = User.class.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(user, id);
+    }
+
+    private void setVetUserId(Vet vet, UUID id) throws Exception {
+        Field field = Vet.class.getDeclaredField("userId");
+        field.setAccessible(true);
+        field.set(vet, id);
+    }
+
 }


### PR DESCRIPTION
Added VetResponseTest to verify DTO mapping from Vet entity Covered mapping of all fields including nested User and Clinic data Added test case for null clinic scenario
Used reflection to simulate JPA-generated IDs for User and Vet (@MapsId) Ensures correct handling of active status and optional fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for veterinarian response mapping covering cases where a clinic is present or absent.
  * Verifies mapped fields (user ID, name, email, license, specialization, booking info, clinic name) and active/inactive status to ensure consistent response output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->