### PR TITLE
test: add unit tests for UserController

### DIFF
--- a/src/test/java/org/example/vet1177/controller/PetControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/PetControllerTest.java
@@ -1,9 +1,6 @@
 package org.example.vet1177.controller;
 
 //Används i commentControllerTest också, verkar funka där?
-import org.example.vet1177.security.CustomUserDetailsService;
-import org.example.vet1177.security.JwtService;
-import org.springframework.test.context.ActiveProfiles;
 import tools.jackson.databind.ObjectMapper;
 import org.example.vet1177.exception.ResourceNotFoundException;
 import org.example.vet1177.dto.request.pet.PetRequest;
@@ -38,7 +35,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(PetController.class)
 @Import(SecurityConfig.class)
-@ActiveProfiles("test")
 public class PetControllerTest {
 
     @Autowired
@@ -50,27 +46,24 @@ public class PetControllerTest {
     @MockitoBean
     private UserService userService;
 
-    @MockitoBean
-    private CustomUserDetailsService customUserDetailsService;
-
-    @MockitoBean
-    private JwtService jwtService;
-
     private User owner;
     private User vet;
     private Pet pet;
     private UUID ownerId;
     private UUID petId;
 
-
-
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         ownerId = UUID.randomUUID();
         petId = UUID.randomUUID();
         owner = new User("Anna Ägare", "anna@mail.se", "hash", Role.OWNER);
         vet = new User("Dr. Erik Vet", "erik@vet.se", "hash", Role.VET);
         pet = new Pet(owner, "Molly", "Hund", "Labrador", LocalDate.of(2020, 1, 1), new BigDecimal("12.50"));
+    }
+    private RequestPostProcessor authenticatedAs(User user) {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                user, null, user.getAuthorities()
+        ));
     }
 
     private PetRequest validPetRequest() {
@@ -81,12 +74,6 @@ public class PetControllerTest {
         request.setDateOfBirth(LocalDate.of(2020, 1, 1));
         request.setWeightKg(new BigDecimal("12.50"));
         return request;
-    }
-
-    private RequestPostProcessor authenticatedAs(User user) {
-        return authentication(new UsernamePasswordAuthenticationToken(
-                user, null, user.getAuthorities()
-        ));
     }
 
     //POST /pets

--- a/src/test/java/org/example/vet1177/controller/PetControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/PetControllerTest.java
@@ -1,6 +1,9 @@
 package org.example.vet1177.controller;
 
 //Används i commentControllerTest också, verkar funka där?
+import org.example.vet1177.security.CustomUserDetailsService;
+import org.example.vet1177.security.JwtService;
+import org.springframework.test.context.ActiveProfiles;
 import tools.jackson.databind.ObjectMapper;
 import org.example.vet1177.exception.ResourceNotFoundException;
 import org.example.vet1177.dto.request.pet.PetRequest;
@@ -35,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(PetController.class)
 @Import(SecurityConfig.class)
+@ActiveProfiles("test")
 public class PetControllerTest {
 
     @Autowired
@@ -46,24 +50,27 @@ public class PetControllerTest {
     @MockitoBean
     private UserService userService;
 
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
     private User owner;
     private User vet;
     private Pet pet;
     private UUID ownerId;
     private UUID petId;
 
+
+
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         ownerId = UUID.randomUUID();
         petId = UUID.randomUUID();
         owner = new User("Anna Ägare", "anna@mail.se", "hash", Role.OWNER);
         vet = new User("Dr. Erik Vet", "erik@vet.se", "hash", Role.VET);
         pet = new Pet(owner, "Molly", "Hund", "Labrador", LocalDate.of(2020, 1, 1), new BigDecimal("12.50"));
-    }
-    private RequestPostProcessor authenticatedAs(User user) {
-        return authentication(new UsernamePasswordAuthenticationToken(
-                user, null, user.getAuthorities()
-        ));
     }
 
     private PetRequest validPetRequest() {
@@ -74,6 +81,12 @@ public class PetControllerTest {
         request.setDateOfBirth(LocalDate.of(2020, 1, 1));
         request.setWeightKg(new BigDecimal("12.50"));
         return request;
+    }
+
+    private RequestPostProcessor authenticatedAs(User user) {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                user, null, user.getAuthorities()
+        ));
     }
 
     //POST /pets

--- a/src/test/java/org/example/vet1177/controller/UserControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/UserControllerTest.java
@@ -139,6 +139,20 @@ class UserControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
+        verify(userService, never()).createUser(any());
+    }
+
+    @Test
+    void createUser_whenNameMissing_shouldReturn400() throws Exception {
+        UserRequest request = validUserRequest();
+        request.setName("");
+
+        mockMvc.perform(post("/api/users")
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        verify(userService, never()).createUser(any());
     }
 
     @Test

--- a/src/test/java/org/example/vet1177/controller/UserControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/UserControllerTest.java
@@ -1,5 +1,8 @@
 package org.example.vet1177.controller;
 
+import org.example.vet1177.dto.request.user.UserUpdateRequest;
+import org.example.vet1177.exception.BusinessRuleException;
+import org.springframework.http.MediaType;
 import tools.jackson.databind.ObjectMapper;
 import org.example.vet1177.dto.request.user.UserRequest;
 
@@ -112,4 +115,95 @@ class UserControllerTest {
                         .with(authenticatedAs(currentUser)))
                 .andExpect(status().isNotFound());
     }
+
+
+    // POST /api/users
+
+
+    @Test
+    void createUser_shouldReturn201WithUserResponse() throws Exception {
+        when(userService.createUser(any())).thenReturn(userResponse);
+
+        mockMvc.perform(post("/api/users")
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validUserRequest())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Anna Karlsson"));
+    }
+
+    @Test
+    void createUser_whenInvalidRequest_shouldReturn400() throws Exception {
+        UserRequest request = validUserRequest();
+        request.setEmail("inte-en-email");
+
+        mockMvc.perform(post("/api/users")
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createUser_whenEmailAlreadyTaken_shouldReturn400() throws Exception {
+        when(userService.createUser(any()))
+                .thenThrow(new BusinessRuleException("Email används redan"));
+
+        mockMvc.perform(post("/api/users")
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validUserRequest())))
+                .andExpect(status().isBadRequest());
+    }
+
+
+    // PUT /api/users/{id}
+
+
+    @Test
+    void updateUser_shouldReturn200WithUpdatedUserResponse() throws Exception {
+        UserResponse updated = new UserResponse(userId, "Uppdaterad Namn", "anna@example.se", Role.OWNER, null, null, null);
+        when(userService.updateUser(eq(userId), any())).thenReturn(updated);
+
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setName("Uppdaterad Namn");
+
+        mockMvc.perform(put("/api/users/{id}", userId)
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Uppdaterad Namn"));
+    }
+
+    @Test
+    void updateUser_whenNotFound_shouldReturn404() throws Exception {
+        when(userService.updateUser(any(), any()))
+                .thenThrow(new ResourceNotFoundException("User", userId));
+
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setName("Uppdaterad Namn");
+
+        mockMvc.perform(put("/api/users/{id}", userId)
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void updateUser_whenBusinessRuleViolation_shouldReturn400() throws Exception {
+        when(userService.updateUser(any(), any()))
+                .thenThrow(new BusinessRuleException("Email används redan"));
+
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setEmail("tagen@example.se");
+
+        mockMvc.perform(put("/api/users/{id}", userId)
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
 }

--- a/src/test/java/org/example/vet1177/controller/UserControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/UserControllerTest.java
@@ -3,7 +3,6 @@ package org.example.vet1177.controller;
 import org.example.vet1177.dto.request.user.UserUpdateRequest;
 import org.example.vet1177.exception.BusinessRuleException;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import tools.jackson.databind.ObjectMapper;
 import org.example.vet1177.dto.request.user.UserRequest;
 
@@ -36,7 +35,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(UserController.class)
 @Import(SecurityConfig.class)
-@ActiveProfiles("test")
 class UserControllerTest {
 
     @Autowired
@@ -47,6 +45,12 @@ class UserControllerTest {
 
     @MockitoBean
     private UserService userService;
+
+    @MockitoBean
+    private org.example.vet1177.security.JwtService jwtService;
+
+    @MockitoBean
+    private org.example.vet1177.security.CustomUserDetailsService customUserDetailsService;
 
     private User currentUser;
     private UserResponse userResponse;

--- a/src/test/java/org/example/vet1177/controller/UserControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/UserControllerTest.java
@@ -3,6 +3,7 @@ package org.example.vet1177.controller;
 import org.example.vet1177.dto.request.user.UserUpdateRequest;
 import org.example.vet1177.exception.BusinessRuleException;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import tools.jackson.databind.ObjectMapper;
 import org.example.vet1177.dto.request.user.UserRequest;
 
@@ -32,8 +33,10 @@ import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 @WebMvcTest(UserController.class)
 @Import(SecurityConfig.class)
+@ActiveProfiles("test")
 class UserControllerTest {
 
     @Autowired

--- a/src/test/java/org/example/vet1177/controller/UserControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/UserControllerTest.java
@@ -143,19 +143,6 @@ class UserControllerTest {
     }
 
     @Test
-    void createUser_whenNameMissing_shouldReturn400() throws Exception {
-        UserRequest request = validUserRequest();
-        request.setName("");
-
-        mockMvc.perform(post("/api/users")
-                        .with(authenticatedAs(currentUser))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
-        verify(userService, never()).createUser(any());
-    }
-
-    @Test
     void createUser_whenEmailAlreadyTaken_shouldReturn400() throws Exception {
         when(userService.createUser(any()))
                 .thenThrow(new BusinessRuleException("Email används redan"));

--- a/src/test/java/org/example/vet1177/controller/UserControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/UserControllerTest.java
@@ -1,9 +1,5 @@
 package org.example.vet1177.controller;
 
-import org.example.vet1177.dto.request.user.UserUpdateRequest;
-import org.example.vet1177.exception.BusinessRuleException;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import tools.jackson.databind.ObjectMapper;
 import org.example.vet1177.dto.request.user.UserRequest;
 
@@ -33,10 +29,8 @@ import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 @WebMvcTest(UserController.class)
 @Import(SecurityConfig.class)
-@ActiveProfiles("test")
 class UserControllerTest {
 
     @Autowired
@@ -51,12 +45,6 @@ class UserControllerTest {
     private User currentUser;
     private UserResponse userResponse;
     private UUID userId;
-
-    @MockitoBean
-    private org.example.vet1177.security.JwtService jwtService;
-    @MockitoBean
-    private org.example.vet1177.security.CustomUserDetailsService customUserDetailsService;
-
 
     @BeforeEach
     void setUp() {
@@ -124,124 +112,4 @@ class UserControllerTest {
                         .with(authenticatedAs(currentUser)))
                 .andExpect(status().isNotFound());
     }
-
-    // POST /api/users
-    @Test
-    void createUser_shouldReturn201WithUserResponse() throws Exception {
-        when(userService.createUser(any())).thenReturn(userResponse);
-
-        mockMvc.perform(post("/api/users")
-                        .with(authenticatedAs(currentUser))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(validUserRequest())))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.name").value("Anna Karlsson"));
-    }
-
-    @Test
-    void createUser_whenInvalidRequest_shouldReturn400() throws Exception {
-        UserRequest request = validUserRequest();
-        request.setEmail("inte-en-email");
-
-        mockMvc.perform(post("/api/users")
-                        .with(authenticatedAs(currentUser))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
-        verify(userService, never()).createUser(any());
-    }
-
-    @Test
-    void createUser_whenEmailAlreadyTaken_shouldReturn400() throws Exception {
-        when(userService.createUser(any()))
-                .thenThrow(new BusinessRuleException("Email används redan"));
-
-        mockMvc.perform(post("/api/users")
-                        .with(authenticatedAs(currentUser))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(validUserRequest())))
-                .andExpect(status().isBadRequest());
-    }
-
-
-    // PUT /api/users/{id}
-
-
-    @Test
-    void updateUser_shouldReturn200WithUpdatedUserResponse() throws Exception {
-        UserResponse updated = new UserResponse(userId, "Uppdaterad Namn", "anna@example.se", Role.OWNER, null, null, null);
-        when(userService.updateUser(eq(userId), any())).thenReturn(updated);
-
-        UserUpdateRequest request = new UserUpdateRequest();
-        request.setName("Uppdaterad Namn");
-
-        mockMvc.perform(put("/api/users/{id}", userId)
-                        .with(authenticatedAs(currentUser))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value("Uppdaterad Namn"));
-    }
-
-    @Test
-    void updateUser_whenNotFound_shouldReturn404() throws Exception {
-        when(userService.updateUser(any(), any()))
-                .thenThrow(new ResourceNotFoundException("User", userId));
-
-        UserUpdateRequest request = new UserUpdateRequest();
-        request.setName("Uppdaterad Namn");
-
-        mockMvc.perform(put("/api/users/{id}", userId)
-                        .with(authenticatedAs(currentUser))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void updateUser_whenBusinessRuleViolation_shouldReturn400() throws Exception {
-        when(userService.updateUser(any(), any()))
-                .thenThrow(new BusinessRuleException("Email används redan"));
-
-        UserUpdateRequest request = new UserUpdateRequest();
-        request.setEmail("tagen@example.se");
-
-        mockMvc.perform(put("/api/users/{id}", userId)
-                        .with(authenticatedAs(currentUser))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
-    }
-
-    // DELETE /api/users/{id}
-
-    @Test
-    void deleteUser_shouldReturn204() throws Exception {
-        doNothing().when(userService).deleteUser(userId);
-
-        mockMvc.perform(delete("/api/users/{id}", userId)
-                        .with(authenticatedAs(currentUser)))
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    void deleteUser_whenNotFound_shouldReturn404() throws Exception {
-        doThrow(new ResourceNotFoundException("User", userId))
-                .when(userService).deleteUser(any());
-
-        mockMvc.perform(delete("/api/users/{id}", userId)
-                        .with(authenticatedAs(currentUser)))
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void deleteUser_whenHasLinkedResources_shouldReturn400() throws Exception {
-        doThrow(new BusinessRuleException("Användaren har kopplade djur och kan inte raderas"))
-                .when(userService).deleteUser(any());
-
-        mockMvc.perform(delete("/api/users/{id}", userId)
-                        .with(authenticatedAs(currentUser)))
-                .andExpect(status().isBadRequest());
-    }
 }
-

--- a/src/test/java/org/example/vet1177/controller/UserControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/UserControllerTest.java
@@ -1,0 +1,114 @@
+package org.example.vet1177.controller;
+
+import tools.jackson.databind.ObjectMapper;
+import org.example.vet1177.dto.request.user.UserRequest;
+
+import org.example.vet1177.dto.response.user.UserResponse;
+import org.example.vet1177.entities.Role;
+import org.example.vet1177.entities.User;
+
+import org.example.vet1177.exception.ResourceNotFoundException;
+import org.example.vet1177.security.SecurityConfig;
+import org.example.vet1177.services.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+@WebMvcTest(UserController.class)
+@Import(SecurityConfig.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserService userService;
+
+    private User currentUser;
+    private UserResponse userResponse;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        currentUser = new User("Anna Karlsson", "anna@example.se", "hash", Role.ADMIN);
+        userResponse = new UserResponse(userId, "Anna Karlsson", "anna@example.se", Role.OWNER, null, null, null);
+    }
+
+    private RequestPostProcessor authenticatedAs(User user) {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                user, null, user.getAuthorities()
+        ));
+    }
+
+    private UserRequest validUserRequest() {
+        UserRequest request = new UserRequest();
+        request.setName("Anna Karlsson");
+        request.setEmail("anna@example.se");
+        request.setPassword("lösenord123");
+        request.setRole(Role.OWNER);
+        return request;
+    }
+
+
+    // GET /api/users
+
+    @Test
+    void getAllUsers_shouldReturn200WithList() throws Exception {
+        when(userService.getAllUsers()).thenReturn(List.of(userResponse));
+
+        mockMvc.perform(get("/api/users")
+                        .with(authenticatedAs(currentUser)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Anna Karlsson"));
+    }
+
+    @Test
+    void getAllUsers_whenEmpty_shouldReturnEmptyList() throws Exception {
+        when(userService.getAllUsers()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/users")
+                        .with(authenticatedAs(currentUser)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    // GET /api/users/{id}
+
+    @Test
+    void getUserById_shouldReturn200WithUserResponse() throws Exception {
+        when(userService.getById(userId)).thenReturn(userResponse);
+
+        mockMvc.perform(get("/api/users/{id}", userId)
+                        .with(authenticatedAs(currentUser)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Anna Karlsson"));
+    }
+
+    @Test
+    void getUserById_whenNotFound_shouldReturn404() throws Exception {
+        when(userService.getById(any()))
+                .thenThrow(new ResourceNotFoundException("User", userId));
+
+        mockMvc.perform(get("/api/users/{id}", userId)
+                        .with(authenticatedAs(currentUser)))
+                .andExpect(status().isNotFound());
+    }}

--- a/src/test/java/org/example/vet1177/controller/UserControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/UserControllerTest.java
@@ -1,5 +1,8 @@
 package org.example.vet1177.controller;
 
+import org.example.vet1177.dto.request.user.UserUpdateRequest;
+import org.example.vet1177.exception.BusinessRuleException;
+import org.springframework.http.MediaType;
 import tools.jackson.databind.ObjectMapper;
 import org.example.vet1177.dto.request.user.UserRequest;
 
@@ -111,4 +114,96 @@ class UserControllerTest {
         mockMvc.perform(get("/api/users/{id}", userId)
                         .with(authenticatedAs(currentUser)))
                 .andExpect(status().isNotFound());
-    }}
+    }
+
+
+    // POST /api/users
+
+
+    @Test
+    void createUser_shouldReturn201WithUserResponse() throws Exception {
+        when(userService.createUser(any())).thenReturn(userResponse);
+
+        mockMvc.perform(post("/api/users")
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validUserRequest())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Anna Karlsson"));
+    }
+
+    @Test
+    void createUser_whenInvalidRequest_shouldReturn400() throws Exception {
+        UserRequest request = validUserRequest();
+        request.setEmail("inte-en-email");
+
+        mockMvc.perform(post("/api/users")
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createUser_whenEmailAlreadyTaken_shouldReturn400() throws Exception {
+        when(userService.createUser(any()))
+                .thenThrow(new BusinessRuleException("Email används redan"));
+
+        mockMvc.perform(post("/api/users")
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validUserRequest())))
+                .andExpect(status().isBadRequest());
+    }
+
+
+    // PUT /api/users/{id}
+
+
+    @Test
+    void updateUser_shouldReturn200WithUpdatedUserResponse() throws Exception {
+        UserResponse updated = new UserResponse(userId, "Uppdaterad Namn", "anna@example.se", Role.OWNER, null, null, null);
+        when(userService.updateUser(eq(userId), any())).thenReturn(updated);
+
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setName("Uppdaterad Namn");
+
+        mockMvc.perform(put("/api/users/{id}", userId)
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Uppdaterad Namn"));
+    }
+
+    @Test
+    void updateUser_whenNotFound_shouldReturn404() throws Exception {
+        when(userService.updateUser(any(), any()))
+                .thenThrow(new ResourceNotFoundException("User", userId));
+
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setName("Uppdaterad Namn");
+
+        mockMvc.perform(put("/api/users/{id}", userId)
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void updateUser_whenBusinessRuleViolation_shouldReturn400() throws Exception {
+        when(userService.updateUser(any(), any()))
+                .thenThrow(new BusinessRuleException("Email används redan"));
+
+        UserUpdateRequest request = new UserUpdateRequest();
+        request.setEmail("tagen@example.se");
+
+        mockMvc.perform(put("/api/users/{id}", userId)
+                        .with(authenticatedAs(currentUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+}

--- a/src/test/java/org/example/vet1177/controller/UserControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/UserControllerTest.java
@@ -52,6 +52,12 @@ class UserControllerTest {
     private UserResponse userResponse;
     private UUID userId;
 
+    @MockitoBean
+    private org.example.vet1177.security.JwtService jwtService;
+    @MockitoBean
+    private org.example.vet1177.security.CustomUserDetailsService customUserDetailsService;
+
+
     @BeforeEach
     void setUp() {
         userId = UUID.randomUUID();

--- a/src/test/java/org/example/vet1177/controller/UserControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/UserControllerTest.java
@@ -116,10 +116,7 @@ class UserControllerTest {
                 .andExpect(status().isNotFound());
     }
 
-
     // POST /api/users
-
-
     @Test
     void createUser_shouldReturn201WithUserResponse() throws Exception {
         when(userService.createUser(any())).thenReturn(userResponse);
@@ -206,4 +203,35 @@ class UserControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    // DELETE /api/users/{id}
+
+    @Test
+    void deleteUser_shouldReturn204() throws Exception {
+        doNothing().when(userService).deleteUser(userId);
+
+        mockMvc.perform(delete("/api/users/{id}", userId)
+                        .with(authenticatedAs(currentUser)))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deleteUser_whenNotFound_shouldReturn404() throws Exception {
+        doThrow(new ResourceNotFoundException("User", userId))
+                .when(userService).deleteUser(any());
+
+        mockMvc.perform(delete("/api/users/{id}", userId)
+                        .with(authenticatedAs(currentUser)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteUser_whenHasLinkedResources_shouldReturn400() throws Exception {
+        doThrow(new BusinessRuleException("Användaren har kopplade djur och kan inte raderas"))
+                .when(userService).deleteUser(any());
+
+        mockMvc.perform(delete("/api/users/{id}", userId)
+                        .with(authenticatedAs(currentUser)))
+                .andExpect(status().isBadRequest());
+    }
 }
+


### PR DESCRIPTION

Closes #149

Täcker GET /api/users, GET /api/users/{id}, POST /api/users, PUT /api/users/{id} och DELETE /api/users/{id} inklusive happy path, valideringsfel, 404 och affärsregelfel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added and expanded web-layer tests for many controllers to cover authenticated flows, CRUD operations, validation, and error cases (200/201/204, 400/403/404, 500).
* **Security**
  * Introduced JWT-based stateless authentication, user-details lookup, request filtering, and updated security rules so most endpoints require authentication.
* **Documentation**
  * Added a comprehensive Swedish API guide with examples, endpoints, auth/dev workflows, and payload samples.
* **Chores**
  * Added JWT-related configuration and a runtime dependency for JWT support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->