### PR TITLE
feat: Add admin-only endpoint to search user by email 

### DIFF
--- a/src/main/java/org/example/vet1177/controller/UserController.java
+++ b/src/main/java/org/example/vet1177/controller/UserController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.example.vet1177.dto.request.user.UserUpdateRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.util.List;
 import java.util.UUID;
@@ -39,6 +40,15 @@ public class UserController {
     public ResponseEntity<UserResponse> getUserById(@PathVariable UUID id) {
         log.info("GET /api/users/{}", id);
         UserResponse user = userService.getById(id);
+        return ResponseEntity.ok(user);
+    }
+
+    // GET /users/search?email= - Sök användare på email (endast admin)
+    @GetMapping("/search")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<UserResponse> searchByEmail(@RequestParam String email) {
+        log.info("GET /api/users/search?email={}", email);
+        UserResponse user = userService.searchByEmail(email);
         return ResponseEntity.ok(user);
     }
 

--- a/src/main/java/org/example/vet1177/controller/UserController.java
+++ b/src/main/java/org/example/vet1177/controller/UserController.java
@@ -47,7 +47,7 @@ public class UserController {
     @GetMapping("/search")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<UserResponse> searchByEmail(@RequestParam String email) {
-        log.info("GET /api/users/search?email={}", email);
+        log.info("GET /api/users/search");
         UserResponse user = userService.searchByEmail(email);
         return ResponseEntity.ok(user);
     }

--- a/src/main/java/org/example/vet1177/security/SecurityConfig.java
+++ b/src/main/java/org/example/vet1177/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -27,6 +28,8 @@ import java.util.List;
  * läsa jwt.secret-key och jwt.expiration-ms från application.properties och
  * skapa en JwtProperties-bean som kan injiceras i JwtService.
  */
+
+@EnableMethodSecurity
 @Configuration
 @EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {

--- a/src/main/java/org/example/vet1177/services/UserService.java
+++ b/src/main/java/org/example/vet1177/services/UserService.java
@@ -71,6 +71,14 @@ public class UserService {
                 .orElseThrow(() -> new ResourceNotFoundException("User", email));
     }
 
+    // GET /users/search?email= - Returnerar UserResponse DTO till controller (admin only)
+    public UserResponse searchByEmail(String email) {
+        log.debug("Searching user by email={}", email);
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("User", email));
+        return mapToResponse(user);
+    }
+
     // Returnerar User-entiteten, används internt när andra services behöver ett User-objekt. OK? - annars
     public User getUserEntityById(UUID id) {
         log.debug("Fetching user entity id={}", id);


### PR DESCRIPTION

Implementerar GET /api/users/search?email= som endast admins kan använda, enligt issue #132.
Ändringar

UserController — lagt till GET /api/users/search?email= med @PreAuthorize("hasRole('ADMIN')")
UserService — lagt till searchByEmail(String email) som returnerar UserResponse (den befintliga getByEmail() används internt och returnerar entiteten)
SecurityConfig — lagt till @EnableMethodSecurity för att aktivera @PreAuthorize

**Säkerhet**
Endpointen är skyddad med @PreAuthorize("hasRole('ADMIN')") — anrop utan admin-token ger 403 Forbidden, anrop utan token ger 401 Unauthorized.

**Notering**
Manuellt test via Postman väntar på att AuthController (login-endpoint) implementeras. Alla 430 befintliga enhetstester passerar.

Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new user search capability for administrators, enabling searches by email address with consistent response formatting.

* **Security**
  * Enabled method-level authorization controls to enforce role-based access restrictions throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->