### PR TITLE
feat: AuthService och AuthController för login och register

### DIFF
--- a/src/main/java/org/example/vet1177/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/vet1177/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package org.example.vet1177.exception;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
@@ -122,5 +123,12 @@ public class GlobalExceptionHandler {
                 "Missing required header: " + ex.getHeaderName(),
                 null
         );
+    }
+    // Hanterar fel lösenord eller email vid inloggning
+    @ExceptionHandler(BadCredentialsException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorResponse handleBadCredentials(BadCredentialsException ex) {
+        log.warn("Authentication failed: {}", ex.getMessage());
+        return new ErrorResponse(401, "Felaktigt email eller lösenord", null);
     }
 }

--- a/src/main/java/org/example/vet1177/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/vet1177/exception/GlobalExceptionHandler.java
@@ -62,15 +62,15 @@ public class GlobalExceptionHandler {
         return new ErrorResponse(403, "Access denied", null);
     }
 
-    // Business rule violation
+    // Hanterar affärsregelbrott, t.ex. duplicate email eller ogiltiga operationer
     @ExceptionHandler(BusinessRuleException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
     public ErrorResponse handleBusinessRule(BusinessRuleException ex) {
-
         log.warn("Business rule violation: {}", ex.getMessage());
-
-        return new ErrorResponse(400, "Business rule violation", null);
+        return new ErrorResponse(422, ex.getMessage(), null);
     }
+
+
 
     // Fallback (ALLA andra errors)
     @ExceptionHandler(Exception.class)
@@ -131,4 +131,6 @@ public class GlobalExceptionHandler {
         log.warn("Authentication failed: {}", ex.getMessage());
         return new ErrorResponse(401, "Felaktigt email eller lösenord", null);
     }
+
+
 }

--- a/src/main/java/org/example/vet1177/security/AuthController.java
+++ b/src/main/java/org/example/vet1177/security/AuthController.java
@@ -1,0 +1,41 @@
+package org.example.vet1177.security;
+
+import jakarta.validation.Valid;
+import org.example.vet1177.security.auth.dto.AuthRequest;
+import org.example.vet1177.security.auth.dto.AuthResponse;
+import org.example.vet1177.security.auth.dto.RegisterRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthController.class);
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody AuthRequest request) {
+        log.info("POST /api/auth/login");
+        AuthResponse response = authService.login(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
+        log.info("POST /api/auth/register");
+        AuthResponse response = authService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/org/example/vet1177/security/AuthService.java
+++ b/src/main/java/org/example/vet1177/security/AuthService.java
@@ -1,0 +1,71 @@
+package org.example.vet1177.security;
+
+import org.example.vet1177.entities.Role;
+import org.example.vet1177.entities.User;
+import org.example.vet1177.exception.BusinessRuleException;
+import org.example.vet1177.repository.UserRepository;
+import org.example.vet1177.security.auth.dto.AuthRequest;
+import org.example.vet1177.security.auth.dto.AuthResponse;
+import org.example.vet1177.security.auth.dto.RegisterRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthService.class);
+
+    private final AuthenticationManager authenticationManager;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    public AuthService(AuthenticationManager authenticationManager,
+                       PasswordEncoder passwordEncoder,
+                       JwtService jwtService,
+                       UserRepository userRepository) {
+        this.authenticationManager = authenticationManager;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtService = jwtService;
+        this.userRepository = userRepository;
+    }
+
+    public AuthResponse login(AuthRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+                UsernamePasswordAuthenticationToken.unauthenticated(
+                        request.email(), request.password()
+                )
+        );
+
+        User user = (User) authentication.getPrincipal();
+        String token = jwtService.generateToken(user);
+
+        log.info("User logged in: id={} role={}", user.getId(), user.getRole());
+        return new AuthResponse(token, user.getId(), user.getName(), user.getEmail(), user.getRole());
+    }
+
+    public AuthResponse register(RegisterRequest request) {
+        if (userRepository.findByEmail(request.email()).isPresent()) {
+            log.warn("Registration failed - email already exists");
+            throw new BusinessRuleException("Email används redan");
+        }
+
+        User user = new User(
+                request.name(),
+                request.email(),
+                passwordEncoder.encode(request.password()),
+                Role.OWNER
+        );
+
+        userRepository.save(user);
+        String token = jwtService.generateToken(user);
+
+        log.info("User registered: id={} role={}", user.getId(), user.getRole());
+        return new AuthResponse(token, user.getId(), user.getName(), user.getEmail(), user.getRole());
+    }
+}

--- a/src/main/java/org/example/vet1177/security/AuthService.java
+++ b/src/main/java/org/example/vet1177/security/AuthService.java
@@ -9,6 +9,7 @@ import org.example.vet1177.security.auth.dto.AuthResponse;
 import org.example.vet1177.security.auth.dto.RegisterRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -50,11 +51,6 @@ public class AuthService {
     }
 
     public AuthResponse register(RegisterRequest request) {
-        if (userRepository.findByEmail(request.email()).isPresent()) {
-            log.warn("Registration failed - email already exists");
-            throw new BusinessRuleException("Email används redan");
-        }
-
         User user = new User(
                 request.name(),
                 request.email(),
@@ -62,9 +58,14 @@ public class AuthService {
                 Role.OWNER
         );
 
-        userRepository.save(user);
-        String token = jwtService.generateToken(user);
+        try {
+            userRepository.save(user);
+        } catch (DataIntegrityViolationException ex) {
+            log.warn("Registration failed - email already exists");
+            throw new BusinessRuleException("Email används redan");
+        }
 
+        String token = jwtService.generateToken(user);
         log.info("User registered: id={} role={}", user.getId(), user.getRole());
         return new AuthResponse(token, user.getId(), user.getName(), user.getEmail(), user.getRole());
     }

--- a/src/main/java/org/example/vet1177/services/UserService.java
+++ b/src/main/java/org/example/vet1177/services/UserService.java
@@ -29,7 +29,6 @@ public class UserService {
 
     private static final Logger log = LoggerFactory.getLogger(UserService.class);
 
-    // TODO: Implementera Spring Security för autentisering och auktorisering
     private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
     private final UserRepository userRepository;
     private final ClinicRepository clinicRepository;
@@ -64,7 +63,6 @@ public class UserService {
         }
     }
 
-    // TODO: GET /users/search?email= - Sök användare på email, kräver ADMIN-roll (implementera när Spring Security är på plats)
     public User getByEmail(String email){
         log.debug("Fetching user by email={}", email);
         return userRepository.findByEmail(email)

--- a/src/test/java/org/example/vet1177/controller/UserControllerTest.java
+++ b/src/test/java/org/example/vet1177/controller/UserControllerTest.java
@@ -150,7 +150,7 @@ class UserControllerTest {
     }
 
     @Test
-    void createUser_whenEmailAlreadyTaken_shouldReturn400() throws Exception {
+    void createUser_whenEmailAlreadyTaken_shouldReturn422() throws Exception {
         when(userService.createUser(any()))
                 .thenThrow(new BusinessRuleException("Email används redan"));
 
@@ -158,7 +158,7 @@ class UserControllerTest {
                         .with(authenticatedAs(currentUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(validUserRequest())))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnprocessableEntity());
     }
 
 
@@ -197,7 +197,7 @@ class UserControllerTest {
     }
 
     @Test
-    void updateUser_whenBusinessRuleViolation_shouldReturn400() throws Exception {
+    void updateUser_whenBusinessRuleViolation_shouldReturn422() throws Exception {
         when(userService.updateUser(any(), any()))
                 .thenThrow(new BusinessRuleException("Email används redan"));
 
@@ -208,7 +208,7 @@ class UserControllerTest {
                         .with(authenticatedAs(currentUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnprocessableEntity());
     }
 
     // DELETE /api/users/{id}
@@ -233,13 +233,13 @@ class UserControllerTest {
     }
 
     @Test
-    void deleteUser_whenHasLinkedResources_shouldReturn400() throws Exception {
+    void deleteUser_whenHasLinkedResources_shouldReturn422() throws Exception {
         doThrow(new BusinessRuleException("Användaren har kopplade djur och kan inte raderas"))
                 .when(userService).deleteUser(any());
 
         mockMvc.perform(delete("/api/users/{id}", userId)
                         .with(authenticatedAs(currentUser)))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnprocessableEntity());
     }
 }
 

--- a/src/test/java/org/example/vet1177/integration/vet/VetIntegrationTest.java
+++ b/src/test/java/org/example/vet1177/integration/vet/VetIntegrationTest.java
@@ -189,7 +189,8 @@ class VetIntegrationTest {
                         .with(authentication(auth(admin)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnprocessableEntity());
+
 
         assertEquals(1, vetRepository.count());
         assertTrue(vetRepository.existsByLicenseId("LIC-DUP-1"));


### PR DESCRIPTION
Implementerar autentiseringsflödet med login och registrering, kopplat till det befintliga JWT- och Spring Security-upplägget.

**Ändringar**
AuthService.java, affärslogik för autentisering:

- login() autentiserar via AuthenticationManager och returnerar JWT
- register() skapar ny användare med hashat lösenord och returnerar JWT
- Admin-registrering är blockerad, nya användare får rollen OWNER
- Duplicate email ger tydligt felmeddelande

AuthController.java — REST-endpoints:

- POST /api/auth/login → returnerar 200 OK med JWT
- POST /api/auth/register → returnerar 201 Created med JWT
- Båda endpoints använder @Valid för input-validering
- Öppna endpoints (ingen JWT krävs), redan konfigurerade som permitAll() i SecurityConfig

GlobalExceptionHandler.java - lagt till handler för BadCredentialsException som returnerar 401 Unauthorized vid fel lösenord

**Säkerhet**

Lösenord loggas aldrig
Lösenord hashas med BCrypt
JWT genereras via befintlig JwtService

Closes #198
Closes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user authentication: login and registration endpoints with token-based access and automatic role assignment.

* **Bug Fixes**
  * Clearer authentication failure feedback with 401 responses and localized error message.
  * Business-rule errors now return 422 with specific error details.

* **Chores**
  * Minor cleanup of internal service comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->