### PR TITLE
 bugfix: register dev auth filter inside Spring Security

### DIFF
--- a/src/main/java/org/example/vet1177/config/DevSecurityConfig.java
+++ b/src/main/java/org/example/vet1177/config/DevSecurityConfig.java
@@ -4,6 +4,7 @@ import org.example.vet1177.repository.UserRepository;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -68,7 +69,7 @@ public class DevSecurityConfig {
      */
     @Bean
     public FilterRegistrationBean<OncePerRequestFilter> devAuthFilterRegistration(
-            @Lazy OncePerRequestFilter devAuthFilter) {
+            @Lazy @Qualifier("devAuthFilter") OncePerRequestFilter devAuthFilter) {
         FilterRegistrationBean<OncePerRequestFilter> registration = new FilterRegistrationBean<>(devAuthFilter);
         registration.setEnabled(false);
         return registration;

--- a/src/main/java/org/example/vet1177/config/DevSecurityConfig.java
+++ b/src/main/java/org/example/vet1177/config/DevSecurityConfig.java
@@ -1,7 +1,7 @@
 package org.example.vet1177.config;
 
-import org.example.vet1177.entities.User;
 import org.example.vet1177.repository.UserRepository;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -26,7 +26,12 @@ public class DevSecurityConfig {
         this.userRepository = userRepository;
     }
 
-    @Bean
+    /**
+     * Skapar dev-autentiseringsfiltret som läser X-Dev-User-headern.
+     * Registreras INTE automatiskt som servlet-filter (se devAuthFilterRegistration).
+     * Läggs istället till inuti Spring Security's filter-kedja via SecurityConfig.
+     */
+    @Bean("devAuthFilter")
     public OncePerRequestFilter devAuthFilter() {
         return new OncePerRequestFilter() {
             @Override
@@ -54,5 +59,18 @@ public class DevSecurityConfig {
                 filterChain.doFilter(request, response);
             }
         };
+    }
+
+    /**
+     * Förhindrar att Spring Boot auto-registrerar devAuthFilter som servlet-filter.
+     * Vi lägger till det manuellt i SecurityConfig istället, inuti säkerhetskedjan.
+     * (Måste vara inuti kedjan — annars skriver SecurityContextHolderFilter över SecurityContext.)
+     */
+    @Bean
+    public FilterRegistrationBean<OncePerRequestFilter> devAuthFilterRegistration(
+            @Lazy OncePerRequestFilter devAuthFilter) {
+        FilterRegistrationBean<OncePerRequestFilter> registration = new FilterRegistrationBean<>(devAuthFilter);
+        registration.setEnabled(false);
+        return registration;
     }
 }

--- a/src/main/java/org/example/vet1177/entities/ActivityLog.java
+++ b/src/main/java/org/example/vet1177/entities/ActivityLog.java
@@ -17,14 +17,20 @@ public class ActivityLog {
     @Column(nullable = false)
     private ActivityType action;
 
-    @Column(nullable = false)
+    // Matchar schema.sql kolumnen "details"
+    @Column(name = "details")
     private String description;
+
+    // entity_type är NOT NULL i schema — sätts alltid till "MEDICAL_RECORD"
+    @Column(name = "entity_type", nullable = false)
+    private String entityType = "MEDICAL_RECORD";
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "performed_by", nullable = false)
     private User performedBy;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
+    // Matchar schema.sql kolumnen "performed_at"
+    @Column(name = "performed_at", nullable = false, updatable = false)
     private Instant createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/example/vet1177/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/vet1177/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package org.example.vet1177.exception;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
@@ -71,6 +72,14 @@ public class GlobalExceptionHandler {
     }
 
 
+
+    // @PreAuthorize kastar AccessDeniedException — måste fångas innan den generiska handlern
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ErrorResponse handleAccessDenied(AccessDeniedException ex) {
+        log.warn("Access denied: {}", ex.getMessage());
+        return new ErrorResponse(403, "Access denied", null);
+    }
 
     // Fallback (ALLA andra errors)
     @ExceptionHandler(Exception.class)

--- a/src/main/java/org/example/vet1177/security/SecurityConfig.java
+++ b/src/main/java/org/example/vet1177/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package org.example.vet1177.security;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.util.List;
 
@@ -37,6 +40,11 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomUserDetailsService userDetailsService;
 
+    // Null i prod — bara satt när dev-profilen är aktiv (injiceras från DevSecurityConfig)
+    @Autowired(required = false)
+    @Qualifier("devAuthFilter")
+    private OncePerRequestFilter devAuthFilter;
+
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
                           CustomUserDetailsService userDetailsService) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
@@ -50,7 +58,7 @@ public class SecurityConfig {
      */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        return http
+        http
                 // CORS — tillåter frontend (annan port/domän) att anropa vårt API.
                 // Utan detta blockerar webbläsaren alla cross-origin requests.
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
@@ -80,9 +88,15 @@ public class SecurityConfig {
                 // Registrera vårt JWT-filter FÖRE Springs inbyggda UsernamePasswordAuthenticationFilter.
                 // Det betyder att JWT-filtret körs först och sätter SecurityContext
                 // innan Spring kollar om användaren har rätt behörighet.
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
-                .build();
+        // Dev-profil: X-Dev-User-filtret läggs inuti säkerhetskedjan FÖRE JWT-filtret.
+        // Måste vara inuti kedjan — annars skriver SecurityContextHolderFilter över SecurityContext.
+        if (devAuthFilter != null) {
+            http.addFilterBefore(devAuthFilter, JwtAuthenticationFilter.class);
+        }
+
+        return http.build();
     }
 
     /**


### PR DESCRIPTION
  filter chain

  DevSecurityConfig's X-Dev-User filter was auto-registered
   as a servlet filter,
  causing SecurityContextHolderFilter to reset the
  SecurityContext before auth
  could be checked. Moved it inside the security chain via
  SecurityConfig.
  Also reverted incorrect ObjectMapper import in controller
   tests to tools.jackson.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved servlet filter registration management for authentication configuration.
  * Enhanced conditional filter chain setup for better control over authentication filter initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->