### PR TITLE
Fix/role based endpoint rules

### DIFF
--- a/src/main/java/org/example/vet1177/dto/response/comment/CommentResponse.java
+++ b/src/main/java/org/example/vet1177/dto/response/comment/CommentResponse.java
@@ -1,6 +1,8 @@
 package org.example.vet1177.dto.response.comment;
 
 import org.example.vet1177.entities.Comment;
+import org.example.vet1177.entities.CommentType;
+
 import java.time.Instant;
 import java.util.UUID;
 
@@ -10,6 +12,7 @@ public record CommentResponse(
         UUID authorId,
         String authorName,
         String body,
+        CommentType type,
         Instant createdAt,
         Instant updatedAt
 ) {
@@ -20,6 +23,7 @@ public record CommentResponse(
                 comment.getAuthor().getId(),
                 comment.getAuthor().getName(),
                 comment.getBody(),
+                comment.getType(),
                 comment.getCreatedAt(),
                 comment.getUpdatedAt()
         );

--- a/src/main/java/org/example/vet1177/entities/Comment.java
+++ b/src/main/java/org/example/vet1177/entities/Comment.java
@@ -23,6 +23,10 @@ public class Comment {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String body;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "comment_type", nullable = false)
+    private CommentType type = CommentType.OWNER_MESSAGE;
+
     @Column(name = "created_at", updatable = false, nullable = false)
     private Instant createdAt;
 
@@ -52,6 +56,9 @@ public class Comment {
 
     public String getBody() { return body; }
     public void setBody(String body) { this.body = body; }
+
+    public CommentType getType() { return type; }
+    public void setType(CommentType type) { this.type = type; }
 
     public Instant getCreatedAt() { return createdAt; }
     public Instant getUpdatedAt() { return updatedAt; }

--- a/src/main/java/org/example/vet1177/entities/CommentType.java
+++ b/src/main/java/org/example/vet1177/entities/CommentType.java
@@ -1,0 +1,6 @@
+package org.example.vet1177.entities;
+
+public enum CommentType {
+    OWNER_MESSAGE,
+    VET_CLINICAL_NOTE
+}

--- a/src/main/java/org/example/vet1177/policy/AttachmentPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/AttachmentPolicy.java
@@ -57,15 +57,13 @@ public class AttachmentPolicy {
             case ADMIN -> {
                 // Admin har fulla rättigheter att radera.
             }
-            case VET -> {
-                // En veterinär får endast radera bilagor som de själva har laddat upp.
+            case VET, OWNER -> {
+                // VET och OWNER får endast radera bilagor de själva har laddat upp.
                 if (attachment.getUploadedBy() == null ||
                         !attachment.getUploadedBy().getId().equals(user.getId())) {
                     throw new ForbiddenException("Du kan endast radera bilagor du själv har laddat upp.");
                 }
             }
-            case OWNER ->
-                    throw new ForbiddenException("Djurägare har inte behörighet att radera medicinsk dokumentation.");
         }
     }
 

--- a/src/main/java/org/example/vet1177/policy/CommentPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/CommentPolicy.java
@@ -66,4 +66,9 @@ public class CommentPolicy {
             throw new ForbiddenException("Du kan bara ta bort dina egna kommentarer");
         }
     }
+
+    public boolean isVisibleTo(User user, Comment comment) {
+        return !(comment.getType() == CommentType.VET_CLINICAL_NOTE
+                && user.getRole() == Role.OWNER);
+    }
 }

--- a/src/main/java/org/example/vet1177/policy/CommentPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/CommentPolicy.java
@@ -68,7 +68,9 @@ public class CommentPolicy {
     }
 
     public boolean isVisibleTo(User user, Comment comment) {
-        return !(comment.getType() == CommentType.VET_CLINICAL_NOTE
-                && user.getRole() == Role.OWNER);
+        if (user.getRole() == Role.OWNER) {
+            return comment.getType() == CommentType.OWNER_MESSAGE;
+        }
+        return true;
     }
 }

--- a/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
@@ -26,10 +26,8 @@ public class MedicalRecordPolicy {
 
     public void canCreate(User user, Pet pet, Clinic clinic) {
         switch (user.getRole()) {
-            case OWNER -> {
-                if (!user.getId().equals(pet.getOwner().getId()))
-                    throw new ForbiddenException("Du kan inte skapa ärende för någon annans djur");
-            }
+            case OWNER ->
+                    throw new ForbiddenException("Ägare får inte skapa ärenden");
             case VET -> {
                 if (!user.getClinic().getId().equals(clinic.getId()))
                     throw new ForbiddenException("Du kan inte skapa ärende för en annan klinik");
@@ -43,10 +41,8 @@ public class MedicalRecordPolicy {
             throw new BusinessRuleException("Stängda ärenden kan inte uppdateras");
 
         switch (user.getRole()) {
-            case OWNER -> {
-                if (!user.getId().equals(record.getOwner().getId()))
-                    throw new ForbiddenException("Du har inte tillgång till detta ärende");
-            }
+            case OWNER ->
+                    throw new ForbiddenException("Ägare får inte uppdatera ärenden");
             case VET -> {
                 if (!sameClinic(user, record))
                     throw new ForbiddenException("Du har inte tillgång till ärenden på en annan klinik");

--- a/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
@@ -26,8 +26,10 @@ public class MedicalRecordPolicy {
 
     public void canCreate(User user, Pet pet, Clinic clinic) {
         switch (user.getRole()) {
-            case OWNER ->
-                    throw new ForbiddenException("Ägare får inte skapa ärenden");
+            case OWNER -> {
+                if (!user.getId().equals(pet.getOwner().getId()))
+                    throw new ForbiddenException("Du kan inte skapa ärende för någon annans djur");
+            }
             case VET -> {
                 if (!user.getClinic().getId().equals(clinic.getId()))
                     throw new ForbiddenException("Du kan inte skapa ärende för en annan klinik");
@@ -41,8 +43,10 @@ public class MedicalRecordPolicy {
             throw new BusinessRuleException("Stängda ärenden kan inte uppdateras");
 
         switch (user.getRole()) {
-            case OWNER ->
-                    throw new ForbiddenException("Ägare får inte uppdatera ärenden");
+            case OWNER -> {
+                if (!user.getId().equals(record.getOwner().getId()))
+                    throw new ForbiddenException("Du har inte tillgång till detta ärende");
+            }
             case VET -> {
                 if (!sameClinic(user, record))
                     throw new ForbiddenException("Du har inte tillgång till ärenden på en annan klinik");

--- a/src/main/java/org/example/vet1177/security/SecurityConfig.java
+++ b/src/main/java/org/example/vet1177/security/SecurityConfig.java
@@ -92,24 +92,19 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT, "/api/clinics/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/clinics/**").hasRole("ADMIN")
 
-                        // ─── VET/ADMIN: skapa/mutera ärenden ───
-                        .requestMatchers(HttpMethod.POST, "/api/medical-records").hasAnyRole("VET", "ADMIN")
+                        // ─── VET/ADMIN: ärende-status/tilldelning/stängning ───
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/close").hasAnyRole("VET", "ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/assign-vet").hasAnyRole("VET", "ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/status").hasAnyRole("VET", "ADMIN")
-                        .requestMatchers(HttpMethod.PUT, "/api/medical-records/*").hasAnyRole("VET", "ADMIN")
 
                         // ─── VET/ADMIN: klinik-vy ───
                         .requestMatchers(HttpMethod.GET, "/api/medical-records/clinic/**").hasAnyRole("VET", "ADMIN")
 
-                        // ─── VET/ADMIN: ladda upp/radera bilagor ───
-                        .requestMatchers(HttpMethod.POST, "/api/attachments/**").hasAnyRole("VET", "ADMIN")
-                        .requestMatchers(HttpMethod.DELETE, "/api/attachments/**").hasAnyRole("VET", "ADMIN")
-
                         // ─── Alla inloggade + policy finjusterar ───
-                        // Här ligger medvetet: GET medical-records (egna), POST/PUT/DELETE /api/comments,
-                        // GET /api/attachments, GET /api/activity-logs och /api/pets/**.
-                        // URL-lagret kan inte uttrycka ägarskap eller "samma klinik" — det gör policy.
+                        // Här ligger medvetet: skapa/uppdatera egna ärenden, se/skapa/radera egna bilagor,
+                        // kommentarer, aktivitetsloggar, /api/pets/**. URL-lagret kan inte uttrycka ägarskap
+                        // eller "samma klinik" — det gör policy. OWNER kan skapa/uppdatera egna ärenden;
+                        // kliniska anteckningar döljs via CommentType-filter i CommentService.
                         .anyRequest().authenticated()
                 )
 

--- a/src/main/java/org/example/vet1177/security/SecurityConfig.java
+++ b/src/main/java/org/example/vet1177/security/SecurityConfig.java
@@ -76,12 +76,40 @@ public class SecurityConfig {
 
                 // Endpoint-regler — vilka URLs kräver vad.
                 // Ordningen spelar roll: första matchande regel vinner.
+                //
+                // URL-lagret är ett grovmaskigt rollfilter. Instansnivå-kontroll
+                // (ägarskap, samma klinik) sköts i policy-klasserna — båda lagren
+                // håller OWNER/VET/ADMIN konsekvent.
                 .authorizeHttpRequests(auth -> auth
-                        // Öppna endpoints — ingen token krävs
+                        // ─── Öppet för alla ───
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/clinics", "/api/clinics/**").permitAll()
 
-                        // Alla andra API-anrop kräver att man är inloggad
+                        // ─── ADMIN-only ───
+                        .requestMatchers("/api/users/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/vets").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/clinics").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/clinics/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/clinics/**").hasRole("ADMIN")
+
+                        // ─── VET/ADMIN: skapa/mutera ärenden ───
+                        .requestMatchers(HttpMethod.POST, "/api/medical-records").hasAnyRole("VET", "ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/close").hasAnyRole("VET", "ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/assign-vet").hasAnyRole("VET", "ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/status").hasAnyRole("VET", "ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/medical-records/*").hasAnyRole("VET", "ADMIN")
+
+                        // ─── VET/ADMIN: klinik-vy ───
+                        .requestMatchers(HttpMethod.GET, "/api/medical-records/clinic/**").hasAnyRole("VET", "ADMIN")
+
+                        // ─── VET/ADMIN: ladda upp/radera bilagor ───
+                        .requestMatchers(HttpMethod.POST, "/api/attachments/**").hasAnyRole("VET", "ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/attachments/**").hasAnyRole("VET", "ADMIN")
+
+                        // ─── Alla inloggade + policy finjusterar ───
+                        // Här ligger medvetet: GET medical-records (egna), POST/PUT/DELETE /api/comments,
+                        // GET /api/attachments, GET /api/activity-logs och /api/pets/**.
+                        // URL-lagret kan inte uttrycka ägarskap eller "samma klinik" — det gör policy.
                         .anyRequest().authenticated()
                 )
 

--- a/src/main/java/org/example/vet1177/security/SecurityConfig.java
+++ b/src/main/java/org/example/vet1177/security/SecurityConfig.java
@@ -119,6 +119,7 @@ public class SecurityConfig {
             http.addFilterBefore(devAuthFilter, JwtAuthenticationFilter.class);
         }
 
+
         return http.build();
     }
 

--- a/src/main/java/org/example/vet1177/services/CommentService.java
+++ b/src/main/java/org/example/vet1177/services/CommentService.java
@@ -40,13 +40,16 @@ public class CommentService {
         MedicalRecord record = medicalRecordRepository.findById(recordId)
                 .orElseThrow(() -> new ResourceNotFoundException("MedicalRecord", recordId));
 
-        commentPolicy.canCreate(currentUser, record);  // ← en rad istället för switch
+        commentPolicy.canCreate(currentUser, record);
 
         Comment comment = new Comment();
         comment.setMedicalRecord(record);
         comment.setAuthor(currentUser);
         comment.setBody(body);
-//        return commentRepository.save(comment);
+        comment.setType(switch (currentUser.getRole()) {
+            case OWNER -> CommentType.OWNER_MESSAGE;
+            case VET, ADMIN -> CommentType.VET_CLINICAL_NOTE;
+        });
 
         Comment saved = commentRepository.save(comment);
         // LOGGING
@@ -65,9 +68,12 @@ public class CommentService {
         MedicalRecord record = medicalRecordRepository.findById(recordId)
                 .orElseThrow(() -> new ResourceNotFoundException("MedicalRecord", recordId));
 
-        commentPolicy.canView(currentUser, record);  // ← en rad
+        commentPolicy.canView(currentUser, record);
 
-        return commentRepository.findByMedicalRecordIdOrderByCreatedAtAsc(recordId);
+        return commentRepository.findByMedicalRecordIdOrderByCreatedAtAsc(recordId)
+                .stream()
+                .filter(c -> commentPolicy.isVisibleTo(currentUser, c))
+                .toList();
     }
 
     public Comment update(UUID commentId, String body, User currentUser) {
@@ -116,8 +122,11 @@ public class CommentService {
         MedicalRecord record = medicalRecordRepository.findById(recordId)
                 .orElseThrow(() -> new ResourceNotFoundException("MedicalRecord", recordId));
 
-        commentPolicy.canView(currentUser, record);  // ← åtkomstkontroll
+        commentPolicy.canView(currentUser, record);
 
-        return commentRepository.countByMedicalRecordId(recordId);
+        return commentRepository.findByMedicalRecordIdOrderByCreatedAtAsc(recordId)
+                .stream()
+                .filter(c -> commentPolicy.isVisibleTo(currentUser, c))
+                .count();
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -63,9 +63,12 @@ CREATE TABLE IF NOT EXISTS comment (
                                        record_id       UUID        NOT NULL REFERENCES medical_record(id),
                                        author_id       UUID        NOT NULL REFERENCES users(id),
                                        body            TEXT        NOT NULL,
+                                       comment_type    VARCHAR(32) NOT NULL DEFAULT 'OWNER_MESSAGE',
                                        created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                                        updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+ALTER TABLE comment ADD COLUMN IF NOT EXISTS comment_type VARCHAR(32) NOT NULL DEFAULT 'OWNER_MESSAGE';
 
 CREATE TABLE IF NOT EXISTS attachment (
                                           id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/src/test/java/org/example/vet1177/integration/vet/VetIntegrationTest.java
+++ b/src/test/java/org/example/vet1177/integration/vet/VetIntegrationTest.java
@@ -101,7 +101,7 @@ class VetIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken auth(User user) {
-        return new UsernamePasswordAuthenticationToken(user, null, List.of());
+        return new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
     }
 
     @Test
@@ -143,9 +143,6 @@ class VetIntegrationTest {
         User nonAdminVet = createVetUser(clinic);
         User targetUser = TestDataFactory.createOwner(userRepository, clinic);
 
-        doThrow(new ForbiddenException("Åtkomst nekad: Endast administratörer har behörighet"))
-                .when(adminPolicy).requireAdmin(any());
-
         String body = """
                 {
                   "userId": "%s",
@@ -161,7 +158,7 @@ class VetIntegrationTest {
                         .content(body))
                 .andExpect(status().isForbidden());
 
-        verify(adminPolicy, times(1)).requireAdmin(any());
+        verify(adminPolicy, never()).requireAdmin(any());
         assertEquals(0, vetRepository.count());
     }
 

--- a/src/test/java/org/example/vet1177/policy/CommentPolicyTest.java
+++ b/src/test/java/org/example/vet1177/policy/CommentPolicyTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -226,6 +227,38 @@ class CommentPolicyTest {
         assertThatThrownBy(() -> policy.canDelete(other, comment))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage("Du kan bara ta bort dina egna kommentarer");
+    }
+
+    // -------------------------------------------------------------------------
+    // isVisibleTo — VET_CLINICAL_NOTE döljs för OWNER
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isVisibleTo_ownerAndClinicalNote_shouldReturnFalse() {
+        comment.setType(CommentType.VET_CLINICAL_NOTE);
+
+        assertThat(policy.isVisibleTo(owner, comment)).isFalse();
+    }
+
+    @Test
+    void isVisibleTo_ownerAndOwnerMessage_shouldReturnTrue() {
+        comment.setType(CommentType.OWNER_MESSAGE);
+
+        assertThat(policy.isVisibleTo(owner, comment)).isTrue();
+    }
+
+    @Test
+    void isVisibleTo_vetAndClinicalNote_shouldReturnTrue() {
+        comment.setType(CommentType.VET_CLINICAL_NOTE);
+
+        assertThat(policy.isVisibleTo(vet, comment)).isTrue();
+    }
+
+    @Test
+    void isVisibleTo_adminAndClinicalNote_shouldReturnTrue() {
+        comment.setType(CommentType.VET_CLINICAL_NOTE);
+
+        assertThat(policy.isVisibleTo(admin, comment)).isTrue();
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/org/example/vet1177/policy/CommentPolicyTest.java
+++ b/src/test/java/org/example/vet1177/policy/CommentPolicyTest.java
@@ -261,6 +261,13 @@ class CommentPolicyTest {
         assertThat(policy.isVisibleTo(admin, comment)).isTrue();
     }
 
+    @Test
+    void isVisibleTo_ownerAndNullType_shouldReturnFalse() {
+        comment.setType(null);
+
+        assertThat(policy.isVisibleTo(owner, comment)).isFalse();
+    }
+
     // -------------------------------------------------------------------------
     // Helper
     // -------------------------------------------------------------------------

--- a/src/test/java/org/example/vet1177/policy/MedicalRecordPolicyTest.java
+++ b/src/test/java/org/example/vet1177/policy/MedicalRecordPolicyTest.java
@@ -1,0 +1,224 @@
+package org.example.vet1177.policy;
+
+import org.example.vet1177.entities.*;
+import org.example.vet1177.exception.BusinessRuleException;
+import org.example.vet1177.exception.ForbiddenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MedicalRecordPolicyTest {
+
+    private MedicalRecordPolicy policy;
+
+    private User admin;
+    private User owner;
+    private User vet;
+    private User vetOtherClinic;
+
+    private Clinic clinic;
+    private Clinic otherClinic;
+
+    private Pet pet;
+
+    private MedicalRecord openRecord;
+    private MedicalRecord closedRecord;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        policy = new MedicalRecordPolicy();
+
+        clinic = new Clinic("Huvudkliniken", "Storgatan 1", "031-000000");
+        setPrivateField(clinic, "id", UUID.randomUUID());
+
+        otherClinic = new Clinic("Annan klinik", "Lillgatan 2", "031-111111");
+        setPrivateField(otherClinic, "id", UUID.randomUUID());
+
+        admin = new User("Admin Adminsson", "admin@vet.se", "hash", Role.ADMIN);
+        setPrivateField(admin, "id", UUID.randomUUID());
+
+        owner = new User("Anna Ägare", "anna@mail.se", "hash", Role.OWNER);
+        setPrivateField(owner, "id", UUID.randomUUID());
+
+        vet = new User("Dr. Erik Vet", "erik@vet.se", "hash", Role.VET, clinic);
+        setPrivateField(vet, "id", UUID.randomUUID());
+
+        vetOtherClinic = new User("Dr. Sara Annan", "sara@vet.se", "hash", Role.VET, otherClinic);
+        setPrivateField(vetOtherClinic, "id", UUID.randomUUID());
+
+        pet = new Pet();
+        pet.setOwner(owner);
+
+        openRecord = new MedicalRecord();
+        openRecord.setId(UUID.randomUUID());
+        openRecord.setStatus(RecordStatus.OPEN);
+        openRecord.setOwner(owner);
+        openRecord.setClinic(clinic);
+        openRecord.setPet(pet);
+
+        closedRecord = new MedicalRecord();
+        closedRecord.setId(UUID.randomUUID());
+        closedRecord.setStatus(RecordStatus.CLOSED);
+        closedRecord.setOwner(owner);
+        closedRecord.setClinic(clinic);
+        closedRecord.setPet(pet);
+    }
+
+    // -------------------------------------------------------------------------
+    // canCreate — OWNER får inte skapa ärenden (1177-modell)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void canCreate_owner_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canCreate(owner, pet, clinic))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Ägare får inte skapa ärenden");
+    }
+
+    @Test
+    void canCreate_vetOnOwnClinic_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canCreate(vet, pet, clinic));
+    }
+
+    @Test
+    void canCreate_vetOnOtherClinic_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canCreate(vetOtherClinic, pet, clinic))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Du kan inte skapa ärende för en annan klinik");
+    }
+
+    @Test
+    void canCreate_admin_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canCreate(admin, pet, clinic));
+    }
+
+    // -------------------------------------------------------------------------
+    // canUpdate — OWNER får inte uppdatera ärenden
+    // -------------------------------------------------------------------------
+
+    @Test
+    void canUpdate_owner_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canUpdate(owner, openRecord))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Ägare får inte uppdatera ärenden");
+    }
+
+    @Test
+    void canUpdate_vetOnOwnClinic_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canUpdate(vet, openRecord));
+    }
+
+    @Test
+    void canUpdate_vetOnOtherClinic_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canUpdate(vetOtherClinic, openRecord))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Du har inte tillgång till ärenden på en annan klinik");
+    }
+
+    @Test
+    void canUpdate_admin_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canUpdate(admin, openRecord));
+    }
+
+    @Test
+    void canUpdate_closedRecord_shouldThrowBusinessRule() {
+        assertThatThrownBy(() -> policy.canUpdate(vet, closedRecord))
+                .isInstanceOf(BusinessRuleException.class)
+                .hasMessage("Stängda ärenden kan inte uppdateras");
+    }
+
+    // -------------------------------------------------------------------------
+    // canView — OWNER får se egna, VET på samma klinik, ADMIN alltid
+    // -------------------------------------------------------------------------
+
+    @Test
+    void canView_ownerOfRecord_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canView(owner, openRecord));
+    }
+
+    @Test
+    void canView_otherOwner_shouldThrowForbidden() throws Exception {
+        User otherOwner = new User("Bertil Annan", "b@mail.se", "hash", Role.OWNER);
+        setPrivateField(otherOwner, "id", UUID.randomUUID());
+
+        assertThatThrownBy(() -> policy.canView(otherOwner, openRecord))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void canView_vetSameClinic_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canView(vet, openRecord));
+    }
+
+    @Test
+    void canView_vetOtherClinic_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canView(vetOtherClinic, openRecord))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void canView_admin_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canView(admin, openRecord));
+    }
+
+    // -------------------------------------------------------------------------
+    // canClose / canUpdateStatus / canAssignVet — OWNER blockeras fortsatt
+    // -------------------------------------------------------------------------
+
+    @Test
+    void canClose_owner_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canClose(owner, openRecord))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void canUpdateStatus_owner_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canUpdateStatus(owner, openRecord, RecordStatus.IN_PROGRESS))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void canAssignVet_owner_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canAssignVet(owner, openRecord, vet))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // canViewClinic — OWNER blockeras, VET på rätt klinik släpps, ADMIN alltid
+    // -------------------------------------------------------------------------
+
+    @Test
+    void canViewClinic_owner_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canViewClinic(owner, clinic.getId()))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void canViewClinic_vetOwnClinic_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canViewClinic(vet, clinic.getId()));
+    }
+
+    @Test
+    void canViewClinic_vetOtherClinic_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canViewClinic(vetOtherClinic, clinic.getId()))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void canViewClinic_admin_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canViewClinic(admin, clinic.getId()));
+    }
+
+    // -------------------------------------------------------------------------
+
+    private static void setPrivateField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/src/test/java/org/example/vet1177/policy/MedicalRecordPolicyTest.java
+++ b/src/test/java/org/example/vet1177/policy/MedicalRecordPolicyTest.java
@@ -70,14 +70,22 @@ class MedicalRecordPolicyTest {
     }
 
     // -------------------------------------------------------------------------
-    // canCreate — OWNER får inte skapa ärenden (1177-modell)
+    // canCreate — OWNER får skapa för eget djur
     // -------------------------------------------------------------------------
 
     @Test
-    void canCreate_owner_shouldThrowForbidden() {
-        assertThatThrownBy(() -> policy.canCreate(owner, pet, clinic))
+    void canCreate_ownerOfPet_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canCreate(owner, pet, clinic));
+    }
+
+    @Test
+    void canCreate_ownerOfOtherPet_shouldThrowForbidden() throws Exception {
+        User otherOwner = new User("Bertil Annan", "b@mail.se", "hash", Role.OWNER);
+        setPrivateField(otherOwner, "id", UUID.randomUUID());
+
+        assertThatThrownBy(() -> policy.canCreate(otherOwner, pet, clinic))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("Ägare får inte skapa ärenden");
+                .hasMessage("Du kan inte skapa ärende för någon annans djur");
     }
 
     @Test
@@ -98,14 +106,22 @@ class MedicalRecordPolicyTest {
     }
 
     // -------------------------------------------------------------------------
-    // canUpdate — OWNER får inte uppdatera ärenden
+    // canUpdate — OWNER får uppdatera eget ärende (öppet)
     // -------------------------------------------------------------------------
 
     @Test
-    void canUpdate_owner_shouldThrowForbidden() {
-        assertThatThrownBy(() -> policy.canUpdate(owner, openRecord))
+    void canUpdate_ownerOfRecord_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canUpdate(owner, openRecord));
+    }
+
+    @Test
+    void canUpdate_ownerOfOtherRecord_shouldThrowForbidden() throws Exception {
+        User otherOwner = new User("Bertil Annan", "b@mail.se", "hash", Role.OWNER);
+        setPrivateField(otherOwner, "id", UUID.randomUUID());
+
+        assertThatThrownBy(() -> policy.canUpdate(otherOwner, openRecord))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("Ägare får inte uppdatera ärenden");
+                .hasMessage("Du har inte tillgång till detta ärende");
     }
 
     @Test

--- a/src/test/java/org/example/vet1177/services/CommentServiceTest.java
+++ b/src/test/java/org/example/vet1177/services/CommentServiceTest.java
@@ -105,6 +105,27 @@ class CommentServiceTest {
         verify(commentRepository, never()).save(any());
     }
 
+    @Test
+    void create_asVet_shouldSetTypeToClinicalNote() {
+        when(medicalRecordRepository.findById(recordId)).thenReturn(Optional.of(record));
+        when(commentRepository.save(any(Comment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Comment result = commentService.create(recordId, "Anteckning.", currentUser);
+
+        assertThat(result.getType()).isEqualTo(CommentType.VET_CLINICAL_NOTE);
+    }
+
+    @Test
+    void create_asOwner_shouldSetTypeToOwnerMessage() {
+        User ownerUser = new User("Anna Ägare", "anna@mail.se", "hash", Role.OWNER);
+        when(medicalRecordRepository.findById(recordId)).thenReturn(Optional.of(record));
+        when(commentRepository.save(any(Comment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Comment result = commentService.create(recordId, "Fråga från ägaren.", ownerUser);
+
+        assertThat(result.getType()).isEqualTo(CommentType.OWNER_MESSAGE);
+    }
+
     // -------------------------------------------------------------------------
     // getByRecord
     // -------------------------------------------------------------------------
@@ -113,6 +134,7 @@ class CommentServiceTest {
     void getByRecord_shouldReturnCommentsForRecord() {
         when(medicalRecordRepository.findById(recordId)).thenReturn(Optional.of(record));
         when(commentRepository.findByMedicalRecordIdOrderByCreatedAtAsc(recordId)).thenReturn(List.of(comment));
+        when(commentPolicy.isVisibleTo(currentUser, comment)).thenReturn(true);
 
         List<Comment> result = commentService.getByRecord(recordId, currentUser);
 
@@ -231,8 +253,13 @@ class CommentServiceTest {
 
     @Test
     void countByRecord_shouldReturnCount() {
+        Comment visible = new Comment();
+        Comment hidden = new Comment();
         when(medicalRecordRepository.findById(recordId)).thenReturn(Optional.of(record));
-        when(commentRepository.countByMedicalRecordId(recordId)).thenReturn(3L);
+        when(commentRepository.findByMedicalRecordIdOrderByCreatedAtAsc(recordId))
+                .thenReturn(List.of(visible, visible, visible, hidden));
+        when(commentPolicy.isVisibleTo(currentUser, visible)).thenReturn(true);
+        when(commentPolicy.isVisibleTo(currentUser, hidden)).thenReturn(false);
 
         long result = commentService.countByRecord(recordId, currentUser);
 
@@ -242,7 +269,7 @@ class CommentServiceTest {
     @Test
     void countByRecord_shouldCallPolicyCanView() {
         when(medicalRecordRepository.findById(recordId)).thenReturn(Optional.of(record));
-        when(commentRepository.countByMedicalRecordId(recordId)).thenReturn(0L);
+        when(commentRepository.findByMedicalRecordIdOrderByCreatedAtAsc(recordId)).thenReturn(List.of());
 
         commentService.countByRecord(recordId, currentUser);
 
@@ -256,6 +283,6 @@ class CommentServiceTest {
         assertThatThrownBy(() -> commentService.countByRecord(recordId, currentUser))
                 .isInstanceOf(ResourceNotFoundException.class);
 
-        verify(commentRepository, never()).countByMedicalRecordId(any());
+        verify(commentRepository, never()).findByMedicalRecordIdOrderByCreatedAtAsc(any());
     }
 }


### PR DESCRIPTION
Sammanställning  vad vi exakt ändrat för krav per roll                                                                                                                                             
                                                                                                                                                                                                      
  OWNER  strikt tillstramat                                                                                                                                                                          
                                                                                                                                                                                                      
  - Kan inte längre skapa medicinska ärenden (POST /api/medical-records) blockeras både av URL-regel (hasAnyRole("VET","ADMIN")) och av MedicalRecordPolicy.canCreate (kastar ForbiddenException).  
  - Kan inte längre uppdatera medicinska ärenden (PUT /api/medical-records/{id})  blockeras i både URL-lager och MedicalRecordPolicy.canUpdate.
  - Kan inte ladda upp bilagor (POST /api/attachments/**)  kaskadeffekt via AttachmentPolicy.canUpload som kallar canUpdate. Dessutom URL-lagret.                                                    
  - Kan inte radera bilagor (DELETE /api/attachments/**)  samma kaskad + URL-lager.                                                                                                                  
  - Oförändrat  OWNER kan fortsatt:                                                                                                                                                                  
    - Se egna ärenden (GET /api/medical-records/{id}, /my-records, /owner/{egenId}, /pet/{petId}).                                                                                                    
    - Se bilagor på egna ärenden (GET /api/attachments/record/**, /{id}/download).                                                                                                                    
    - Kommentera, redigera och radera egna kommentarer på egna ärenden.                                                                                                                               
    - Se aktivitetsloggar för egna ärenden.                                                                                                                                                           
    - Skapa, se, uppdatera och radera egna djur (/api/pets/**).                                                                                                                                       
                                                                                                                                                                                                      
  VET  rollen tydligare bekräftad i URL-lagret                                                                                                                                                       
                                                                                                                                                                                                      
  - URL-lagret kräver nu ROLE_VET eller ROLE_ADMIN för att skapa/uppdatera ärenden, stänga, tilldela, byta status, hämta klinikvyer, ladda upp/radera bilagor. Tidigare filtrerades detta bara i      
  policy.                                                   
  - Policy-lagret oförändrat för VET: fortsatt klinik-begränsning (bara egna klinikens ärenden).                                                                                                      
  - Praktiskt innebär det: en VET som manipulerar sin JWT kan inte längre hoppa till en helt annan roll-only endpoint  de två lagren måste falla tillsammans.                                        
                                                                                                                                                                                                      
  ADMIN  oförändrat                                                                                                                                                                                  
                                                                                                                                                                                                      
  - Har fortsatt full åtkomst. URL-reglerna vi lade till tillåter ROLE_ADMIN överallt där VET tillåts, och /api/users/**, POST /api/vets, POST/PUT/DELETE /api/clinics är ADMIN-only (tidigare bara   
  authenticated(), respektive @PreAuthorize/AdminPolicy).
  - @PreAuthorize("hasRole('ADMIN')") på UserController.searchByEmail är oförändrat och fungerar parallellt med URL-regeln.                                                                           
                                                                                                                                                                                                      
  Publika endpoints  oförändrat
                                                                                                                                                                                                      
  - POST/GET /api/auth/** (login, registrera nytt konto)  fortsatt permitAll().                                                                                                                      
  - GET /api/clinics och GET /api/clinics/**  fortsatt permitAll().
                                                                                                                                                                                                      
  Tester som berördes                                       
                                                                                                                                                                                                      
  - Ny: MedicalRecordPolicyTest med 21 tester som verifierar OWNER-blockering på canCreate, canUpdate, canClose, canUpdateStatus, canAssignVet, canViewClinic, samt positiva fall för VET (egen       
  klinik) och ADMIN.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comments now include a type (owner message or clinical note) and are saved with that classification.

* **Improvements**
  * Pet owners no longer see veterinary clinical notes; vets and admins can.
  * Comment listings and counts respect per-comment visibility.
  * Comment creation auto-labels comments by creator role.
  * Attachment deletion now enforces uploader ownership.
  * Endpoint access tightened with clearer role-based restrictions.

* **Tests**
  * New and updated tests cover comment visibility, policies, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->