### PR TITLE
Fix/owner case creation rights

### DIFF
--- a/src/main/java/org/example/vet1177/policy/AttachmentPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/AttachmentPolicy.java
@@ -2,6 +2,7 @@ package org.example.vet1177.policy;
 
 import org.example.vet1177.entities.Attachment;
 import org.example.vet1177.entities.MedicalRecord;
+import org.example.vet1177.entities.RecordStatus;
 import org.example.vet1177.entities.User;
 import org.example.vet1177.exception.BusinessRuleException;
 import org.example.vet1177.exception.ForbiddenException;
@@ -30,6 +31,8 @@ public class AttachmentPolicy {
         this.medicalRecordPolicy = medicalRecordPolicy;
     }
 
+    // OWNER får ladda upp bilagor på egna öppna case — men får inte uppdatera själva journalen.
+    // Därför kan vi inte kaskadera till MedicalRecordPolicy.canUpdate; egna regler krävs här.
     public void canUpload(User user, MedicalRecord record, String contentType, long fileSize) {
         if (fileSize <= 0) {
             throw new IllegalArgumentException("Filen kan inte vara tom (0 bytes).");
@@ -38,7 +41,20 @@ public class AttachmentPolicy {
         validateFileType(contentType);
         validateFileSize(fileSize);
 
-        medicalRecordPolicy.canUpdate(user, record);
+        switch (user.getRole()) {
+            case ADMIN -> {}
+            case VET -> {
+                if (user.getClinic() == null ||
+                        !user.getClinic().getId().equals(record.getClinic().getId()))
+                    throw new ForbiddenException("Du har inte tillgång till ärenden på en annan klinik");
+            }
+            case OWNER -> {
+                if (!record.getOwner().getId().equals(user.getId()))
+                    throw new ForbiddenException("Du kan bara ladda upp bilagor på egna ärenden");
+                if (record.getStatus() == RecordStatus.CLOSED)
+                    throw new ForbiddenException("Bilagor kan inte laddas upp på stängda ärenden");
+            }
+        }
     }
 
 
@@ -50,19 +66,22 @@ public class AttachmentPolicy {
 
     //Kontrollerar om användaren får radera en bilaga från systemet.
     public void canDelete(User user, Attachment attachment) {
-
-        medicalRecordPolicy.canUpdate(user, attachment.getMedicalRecord());
+        MedicalRecord record = attachment.getMedicalRecord();
 
         switch (user.getRole()) {
+            case OWNER ->
+                    throw new ForbiddenException("Djurägare får inte radera bilagor");
+            case VET -> {
+                if (user.getClinic() == null ||
+                        !user.getClinic().getId().equals(record.getClinic().getId()))
+                    throw new ForbiddenException("Du har inte tillgång till ärenden på en annan klinik");
+                // VET får endast radera bilagor de själva har laddat upp.
+                if (attachment.getUploadedBy() == null ||
+                        !attachment.getUploadedBy().getId().equals(user.getId()))
+                    throw new ForbiddenException("Du kan endast radera bilagor du själv har laddat upp.");
+            }
             case ADMIN -> {
                 // Admin har fulla rättigheter att radera.
-            }
-            case VET, OWNER -> {
-                // VET och OWNER får endast radera bilagor de själva har laddat upp.
-                if (attachment.getUploadedBy() == null ||
-                        !attachment.getUploadedBy().getId().equals(user.getId())) {
-                    throw new ForbiddenException("Du kan endast radera bilagor du själv har laddat upp.");
-                }
             }
         }
     }

--- a/src/main/java/org/example/vet1177/policy/CommentPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/CommentPolicy.java
@@ -67,10 +67,11 @@ public class CommentPolicy {
         }
     }
 
+    // OWNER ser både egna meddelanden och VET:ens journalanteckningar på sitt eget ärende
+    // (jfr 1177-modellen). Åtkomsten till själva ärendet gatas i canView, så det räcker
+    // att alltid returnera true här — finkornig filtrering görs när/om en separat
+    // VET_INTERNAL_NOTE-typ införs.
     public boolean isVisibleTo(User user, Comment comment) {
-        if (user.getRole() == Role.OWNER) {
-            return comment.getType() == CommentType.OWNER_MESSAGE;
-        }
         return true;
     }
 }

--- a/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
@@ -27,8 +27,8 @@ public class MedicalRecordPolicy {
     public void canCreate(User user, Pet pet, Clinic clinic) {
         switch (user.getRole()) {
             case OWNER -> {
-                if (!user.getId().equals(pet.getOwner().getId()))
-                    throw new ForbiddenException("Du kan inte skapa ärende för någon annans djur");
+                if (!pet.getOwner().getId().equals(user.getId()))
+                    throw new ForbiddenException("Du kan bara skapa ärenden för egna djur");
             }
             case VET -> {
                 if (!user.getClinic().getId().equals(clinic.getId()))
@@ -38,27 +38,25 @@ public class MedicalRecordPolicy {
         }
     }
 
+    // Auth-kontroll (roll/ägarskap) körs före isFinal-kontrollen — annars skulle en
+    // OWNER som försöker uppdatera någon annans stängda ärende få "Stängda ärenden
+    // kan inte uppdateras" i stället för 403 (CodeRabbit-kommentar på #216).
     public void canUpdate(User user, MedicalRecord record) {
-        if (record.getStatus().isFinal())
-            throw new BusinessRuleException("Stängda ärenden kan inte uppdateras");
-
         switch (user.getRole()) {
-            case OWNER -> {
-                if (!user.getId().equals(record.getOwner().getId()))
-                    throw new ForbiddenException("Du har inte tillgång till detta ärende");
-            }
+            case OWNER ->
+                    throw new ForbiddenException("Ägare får inte uppdatera journaler");
             case VET -> {
                 if (!sameClinic(user, record))
                     throw new ForbiddenException("Du har inte tillgång till ärenden på en annan klinik");
             }
             case ADMIN -> {}
         }
+
+        if (record.getStatus().isFinal())
+            throw new BusinessRuleException("Stängda ärenden kan inte uppdateras");
     }
 
     public void canUpdateStatus(User user, MedicalRecord record, RecordStatus newStatus) {
-        if (record.getStatus().isFinal())
-            throw new BusinessRuleException("Stängda ärenden kan inte uppdateras");
-
         switch (user.getRole()) {
             case OWNER ->
                     throw new ForbiddenException("Ägare får inte ändra status på ärenden");
@@ -68,6 +66,9 @@ public class MedicalRecordPolicy {
             }
             case ADMIN -> {}
         }
+
+        if (record.getStatus().isFinal())
+            throw new BusinessRuleException("Stängda ärenden kan inte uppdateras");
     }
 
 
@@ -95,9 +96,6 @@ public class MedicalRecordPolicy {
     }
 
     public void canClose(User user, MedicalRecord record) {
-        if (record.getStatus().isFinal())
-            throw new BusinessRuleException("Ärendet är redan stängt");
-
         switch (user.getRole()) {
             case OWNER ->
                     throw new ForbiddenException("Ägare får inte stänga ärenden");
@@ -107,6 +105,9 @@ public class MedicalRecordPolicy {
             }
             case ADMIN -> {}
         }
+
+        if (record.getStatus().isFinal())
+            throw new BusinessRuleException("Ärendet är redan stängt");
     }
 
     public void canViewClinic(User user, UUID clinicId) {

--- a/src/main/java/org/example/vet1177/security/SecurityConfig.java
+++ b/src/main/java/org/example/vet1177/security/SecurityConfig.java
@@ -92,19 +92,25 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT, "/api/clinics/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/clinics/**").hasRole("ADMIN")
 
-                        // ─── VET/ADMIN: ärende-status/tilldelning/stängning ───
+                        // ─── VET/ADMIN: journal-mutation (status/tilldelning/stängning/uppdatering) ───
+                        // Ordningen matters: mer specifika paths (*/close, */status, */assign-vet) före /* så
+                        // att Spring matchar dem innan den generella PUT /api/medical-records/* regeln.
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/close").hasAnyRole("VET", "ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/assign-vet").hasAnyRole("VET", "ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/status").hasAnyRole("VET", "ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/medical-records/*").hasAnyRole("VET", "ADMIN")
 
                         // ─── VET/ADMIN: klinik-vy ───
                         .requestMatchers(HttpMethod.GET, "/api/medical-records/clinic/**").hasAnyRole("VET", "ADMIN")
 
+                        // ─── VET/ADMIN: radera bilagor ───
+                        .requestMatchers(HttpMethod.DELETE, "/api/attachments/**").hasAnyRole("VET", "ADMIN")
+
                         // ─── Alla inloggade + policy finjusterar ───
-                        // Här ligger medvetet: skapa/uppdatera egna ärenden, se/skapa/radera egna bilagor,
-                        // kommentarer, aktivitetsloggar, /api/pets/**. URL-lagret kan inte uttrycka ägarskap
-                        // eller "samma klinik" — det gör policy. OWNER kan skapa/uppdatera egna ärenden;
-                        // kliniska anteckningar döljs via CommentType-filter i CommentService.
+                        // Här ligger medvetet: POST /api/medical-records (OWNER får skapa för eget djur),
+                        // POST /api/attachments/** (OWNER får ladda upp på egna öppna case), GET /api/medical-records,
+                        // GET /api/attachments, kommentarer, aktivitetsloggar, /api/pets/**. URL-lagret kan inte
+                        // uttrycka ägarskap eller "samma klinik" — det gör MedicalRecordPolicy/AttachmentPolicy.
                         .anyRequest().authenticated()
                 )
 

--- a/src/test/java/org/example/vet1177/policy/CommentPolicyTest.java
+++ b/src/test/java/org/example/vet1177/policy/CommentPolicyTest.java
@@ -230,14 +230,15 @@ class CommentPolicyTest {
     }
 
     // -------------------------------------------------------------------------
-    // isVisibleTo — VET_CLINICAL_NOTE döljs för OWNER
+    // isVisibleTo — OWNER ser både VET_CLINICAL_NOTE och OWNER_MESSAGE på eget ärende
+    // (1177-modellen). Åtkomsten till ärendet gatas i canView.
     // -------------------------------------------------------------------------
 
     @Test
-    void isVisibleTo_ownerAndClinicalNote_shouldReturnFalse() {
+    void isVisibleTo_ownerAndClinicalNote_shouldReturnTrue() {
         comment.setType(CommentType.VET_CLINICAL_NOTE);
 
-        assertThat(policy.isVisibleTo(owner, comment)).isFalse();
+        assertThat(policy.isVisibleTo(owner, comment)).isTrue();
     }
 
     @Test
@@ -262,10 +263,10 @@ class CommentPolicyTest {
     }
 
     @Test
-    void isVisibleTo_ownerAndNullType_shouldReturnFalse() {
+    void isVisibleTo_ownerAndNullType_shouldReturnTrue() {
         comment.setType(null);
 
-        assertThat(policy.isVisibleTo(owner, comment)).isFalse();
+        assertThat(policy.isVisibleTo(owner, comment)).isTrue();
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/org/example/vet1177/policy/MedicalRecordPolicyTest.java
+++ b/src/test/java/org/example/vet1177/policy/MedicalRecordPolicyTest.java
@@ -74,18 +74,18 @@ class MedicalRecordPolicyTest {
     // -------------------------------------------------------------------------
 
     @Test
-    void canCreate_ownerOfPet_shouldNotThrow() {
+    void canCreate_ownerOfOwnPet_shouldNotThrow() {
         assertThatNoException().isThrownBy(() -> policy.canCreate(owner, pet, clinic));
     }
 
     @Test
-    void canCreate_ownerOfOtherPet_shouldThrowForbidden() throws Exception {
+    void canCreate_ownerOfOthersPet_shouldThrowForbidden() throws Exception {
         User otherOwner = new User("Bertil Annan", "b@mail.se", "hash", Role.OWNER);
         setPrivateField(otherOwner, "id", UUID.randomUUID());
 
         assertThatThrownBy(() -> policy.canCreate(otherOwner, pet, clinic))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("Du kan inte skapa ärende för någon annans djur");
+                .hasMessage("Du kan bara skapa ärenden för egna djur");
     }
 
     @Test
@@ -106,22 +106,14 @@ class MedicalRecordPolicyTest {
     }
 
     // -------------------------------------------------------------------------
-    // canUpdate — OWNER får uppdatera eget ärende (öppet)
+    // canUpdate — OWNER blockerad helt; VET/ADMIN på samma klinik tillåtna
     // -------------------------------------------------------------------------
 
     @Test
-    void canUpdate_ownerOfRecord_shouldNotThrow() {
-        assertThatNoException().isThrownBy(() -> policy.canUpdate(owner, openRecord));
-    }
-
-    @Test
-    void canUpdate_ownerOfOtherRecord_shouldThrowForbidden() throws Exception {
-        User otherOwner = new User("Bertil Annan", "b@mail.se", "hash", Role.OWNER);
-        setPrivateField(otherOwner, "id", UUID.randomUUID());
-
-        assertThatThrownBy(() -> policy.canUpdate(otherOwner, openRecord))
+    void canUpdate_owner_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canUpdate(owner, openRecord))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("Du har inte tillgång till detta ärende");
+                .hasMessage("Ägare får inte uppdatera journaler");
     }
 
     @Test
@@ -146,6 +138,14 @@ class MedicalRecordPolicyTest {
         assertThatThrownBy(() -> policy.canUpdate(vet, closedRecord))
                 .isInstanceOf(BusinessRuleException.class)
                 .hasMessage("Stängda ärenden kan inte uppdateras");
+    }
+
+    // Auth-kontroll före isFinal-kontroll: en OWNER som ropar canUpdate på stängt ärende
+    // ska få 403 (ForbiddenException), inte 422 (BusinessRuleException).
+    @Test
+    void canUpdate_ownerOnClosedRecord_shouldThrowForbiddenNotBusinessRule() {
+        assertThatThrownBy(() -> policy.canUpdate(owner, closedRecord))
+                .isInstanceOf(ForbiddenException.class);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Efter #216 kunde OWNER inte längre skapa ärenden eller ladda upp bilagor. Den här PR:en särar på "skapa/ladda upp/läsa" från "uppdatera/stänga/radera" så att OWNER fungerar som på 1177  kan       
  registrera och följa sitt eget djurs ärende
                                                                                                                                                                                                       
  OWNER kan                                                                                                                                                                                            
   
  - POST /api/medical-records för eget djur                                                                                                                                                            
  - POST /api/attachments/record/{id} på eget öppet ärende
  - POST /api/comments på eget ärende (typ OWNER_MESSAGE)                                                                                                                                              
  - Läsa eget ärende, egna bilagor och samtliga kommentarer på eget ärende — inklusive VET:ens VET_CLINICAL_NOTE                                                                                       
                                                                                                                                                                                                       
  OWNER kan inte                                                                                                                                                                                       
                                                                                                                                                                                                       
  - PUT /api/medical-records/{id} (journal-uppdatering)                                                                                                                                                
  - PUT /api/medical-records/{id}/status · /close · /assign-vet
  - DELETE /api/attachments/**                                                                                                                                                                         
                                                                                                                                                                                                       
  Ändringar                                                                                                                                                                                            
                                                                                                                                                                                                       
  SecurityConfig                                                                                                                                                                                       
  - PUT /api/medical-records/* och DELETE /api/attachments/** → hasAnyRole("VET","ADMIN")
  - POST /api/medical-records och POST /api/attachments/** faller igenom till authenticated() — policy tar ägarskapet                                                                                  
                  
  MedicalRecordPolicy                                                                                                                                                                                  
  - canCreate: OWNER tillåts för eget djur
  - canUpdate: OWNER spärrad ("Ägare får inte uppdatera journaler")                                                                                                                                    
  - Roll-/ägarskapskontroll körs nu före isFinal → OWNER på stängt ärende får 403, inte 422 (CodeRabbit-kommentar på #216)
                                                                                                                                                                                                       
  AttachmentPolicy                                                                                                                                                                                     
  - canUpload: kaskaden till canUpdate borttagen. Egna regler: ADMIN ✓, VET samma klinik ✓, OWNER eget ärende + ej CLOSED ✓                                                                            
  - canDelete: OWNER spärrad ("Djurägare får inte radera bilagor"); VET/ADMIN oförändrat                                                                                                               
                  
  CommentPolicy                                                                                                                                                                                        
  - isVisibleTo släpper alla roller — OWNER ser VET:ens journalanteckningar på eget ärende (1177-modellen)
                                                                                                                                                                                                       
  Tester          
  - MedicalRecordPolicyTest: uppdaterade canCreate-meddelande, ny canUpdate_owner_shouldThrowForbidden + canUpdate_ownerOnClosedRecord_shouldThrowForbiddenNotBusinessRule                             
  - AttachmentPolicyTest (ny, 14 tester): OWNER/VET/ADMIN × upload/delete, stängt case, fel klinik, tom fil, otillåten content-type                                                                    
  - CommentPolicyTest: fyra isVisibleTo-test uppdaterade till nytt beteende                                                        
                                                                                                                                                                                                       
  Test plan                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                
  - OWNER skapar ärende för eget djur → 201                                                                                                                                                            
  - OWNER laddar upp bilaga på eget öppet ärende → 201; på stängt → 403                                                                                                                                
  - OWNER PUT/status/close/assign-vet + DELETE attachment → 403                                                                                                                                        
  - OWNER ser VET:ens journalanteckning på eget ärende                                                                                                                                                 
  - VET/ADMIN-flöden oförändrade      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced role-based authorization for attachment uploads and deletions; owners are now prohibited from deleting attachments
  * Restricted medical record creation and updates for owners; owners cannot modify journals
  * Improved access controls for veterinarians with clinic affiliation verification
  * Revised comment visibility rules to enable broader access within authorization boundaries

* **Chores**
  * Updated security configuration to enforce authorization changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->