### PR TITLE
Feat/owner create case och attachemnts

### DIFF
--- a/src/main/java/org/example/vet1177/policy/AttachmentPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/AttachmentPolicy.java
@@ -31,8 +31,10 @@ public class AttachmentPolicy {
         this.medicalRecordPolicy = medicalRecordPolicy;
     }
 
-    // OWNER får ladda upp bilagor på egna öppna case — men får inte uppdatera själva journalen.
-    // Därför kan vi inte kaskadera till MedicalRecordPolicy.canUpdate; egna regler krävs här.
+    // VET får alltid ladda upp på öppna ärenden (oavsett klinik) — remiss- och konsultflöden
+    // kräver att remitterande veterinär kan bifoga filer på en annan kliniks ärende.
+    // OWNER får ladda upp på egna öppna ärenden. CLOSED spärrar både VET och OWNER.
+    // ADMIN har inga restriktioner (t.ex. retroaktiv arkivering).
     public void canUpload(User user, MedicalRecord record, String contentType, long fileSize) {
         if (fileSize <= 0) {
             throw new IllegalArgumentException("Filen kan inte vara tom (0 bytes).");
@@ -44,9 +46,8 @@ public class AttachmentPolicy {
         switch (user.getRole()) {
             case ADMIN -> {}
             case VET -> {
-                if (user.getClinic() == null ||
-                        !user.getClinic().getId().equals(record.getClinic().getId()))
-                    throw new ForbiddenException("Du har inte tillgång till ärenden på en annan klinik");
+                if (record.getStatus() == RecordStatus.CLOSED)
+                    throw new ForbiddenException("Bilagor kan inte laddas upp på stängda ärenden");
             }
             case OWNER -> {
                 if (!record.getOwner().getId().equals(user.getId()))

--- a/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
@@ -41,10 +41,14 @@ public class MedicalRecordPolicy {
     // Auth-kontroll (roll/ägarskap) körs före isFinal-kontrollen — annars skulle en
     // OWNER som försöker uppdatera någon annans stängda ärende få "Stängda ärenden
     // kan inte uppdateras" i stället för 403 (CodeRabbit-kommentar på #216).
+    // OWNER får uppdatera eget ärendes titel/beskrivning (DTO:n exponerar bara de fälten).
+    // Status/close/assign-vet gatas i separata policy-metoder och URL-regler.
     public void canUpdate(User user, MedicalRecord record) {
         switch (user.getRole()) {
-            case OWNER ->
-                    throw new ForbiddenException("Ägare får inte uppdatera journaler");
+            case OWNER -> {
+                if (!user.getId().equals(record.getOwner().getId()))
+                    throw new ForbiddenException("Du kan bara uppdatera egna ärenden");
+            }
             case VET -> {
                 if (!sameClinic(user, record))
                     throw new ForbiddenException("Du har inte tillgång till ärenden på en annan klinik");

--- a/src/main/java/org/example/vet1177/security/SecurityConfig.java
+++ b/src/main/java/org/example/vet1177/security/SecurityConfig.java
@@ -92,13 +92,13 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT, "/api/clinics/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/clinics/**").hasRole("ADMIN")
 
-                        // ─── VET/ADMIN: journal-mutation (status/tilldelning/stängning/uppdatering) ───
-                        // Ordningen matters: mer specifika paths (*/close, */status, */assign-vet) före /* så
-                        // att Spring matchar dem innan den generella PUT /api/medical-records/* regeln.
+                        // ─── VET/ADMIN: journal-mutation (status/tilldelning/stängning) ───
+                        // PUT /api/medical-records/{id} (titel/beskrivning) är medvetet utelämnad —
+                        // gatas i MedicalRecordPolicy.canUpdate så att OWNER får uppdatera eget ärende.
+                        // /status, /close, /assign-vet förblir VET/ADMIN-only på URL-nivå.
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/close").hasAnyRole("VET", "ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/assign-vet").hasAnyRole("VET", "ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/status").hasAnyRole("VET", "ADMIN")
-                        .requestMatchers(HttpMethod.PUT, "/api/medical-records/*").hasAnyRole("VET", "ADMIN")
 
                         // ─── VET/ADMIN: klinik-vy ───
                         .requestMatchers(HttpMethod.GET, "/api/medical-records/clinic/**").hasAnyRole("VET", "ADMIN")

--- a/src/test/java/org/example/vet1177/policy/AttachmentPolicyTest.java
+++ b/src/test/java/org/example/vet1177/policy/AttachmentPolicyTest.java
@@ -1,0 +1,210 @@
+package org.example.vet1177.policy;
+
+import org.example.vet1177.entities.*;
+import org.example.vet1177.exception.BusinessRuleException;
+import org.example.vet1177.exception.ForbiddenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AttachmentPolicyTest {
+
+    private AttachmentPolicy policy;
+
+    private User admin;
+    private User owner;
+    private User otherOwner;
+    private User vet;
+    private User vetOtherClinic;
+
+    private Clinic clinic;
+    private Clinic otherClinic;
+
+    private MedicalRecord openRecord;
+    private MedicalRecord closedRecord;
+
+    private Attachment attachmentUploadedByVet;
+
+    private static final String JPEG = "image/jpeg";
+    private static final long SMALL_FILE = 1024L;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        policy = new AttachmentPolicy(new MedicalRecordPolicy());
+
+        clinic = new Clinic("Huvudkliniken", "Storgatan 1", "031-000000");
+        setPrivateField(clinic, "id", UUID.randomUUID());
+
+        otherClinic = new Clinic("Annan klinik", "Lillgatan 2", "031-111111");
+        setPrivateField(otherClinic, "id", UUID.randomUUID());
+
+        admin = new User("Admin Adminsson", "admin@vet.se", "hash", Role.ADMIN);
+        setPrivateField(admin, "id", UUID.randomUUID());
+
+        owner = new User("Anna Ägare", "anna@mail.se", "hash", Role.OWNER);
+        setPrivateField(owner, "id", UUID.randomUUID());
+
+        otherOwner = new User("Bertil Annan", "bertil@mail.se", "hash", Role.OWNER);
+        setPrivateField(otherOwner, "id", UUID.randomUUID());
+
+        vet = new User("Dr. Erik Vet", "erik@vet.se", "hash", Role.VET, clinic);
+        setPrivateField(vet, "id", UUID.randomUUID());
+
+        vetOtherClinic = new User("Dr. Sara Annan", "sara@vet.se", "hash", Role.VET, otherClinic);
+        setPrivateField(vetOtherClinic, "id", UUID.randomUUID());
+
+        openRecord = new MedicalRecord();
+        openRecord.setId(UUID.randomUUID());
+        openRecord.setStatus(RecordStatus.OPEN);
+        openRecord.setOwner(owner);
+        openRecord.setClinic(clinic);
+
+        closedRecord = new MedicalRecord();
+        closedRecord.setId(UUID.randomUUID());
+        closedRecord.setStatus(RecordStatus.CLOSED);
+        closedRecord.setOwner(owner);
+        closedRecord.setClinic(clinic);
+
+        attachmentUploadedByVet = new Attachment();
+        ReflectionTestUtils.setField(attachmentUploadedByVet, "id", UUID.randomUUID());
+        attachmentUploadedByVet.setMedicalRecord(openRecord);
+        attachmentUploadedByVet.setUploadedBy(vet);
+    }
+
+    // -------------------------------------------------------------------------
+    // canUpload
+    // -------------------------------------------------------------------------
+
+    @Test
+    void canUpload_ownerOfOwnOpenRecord_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() ->
+                policy.canUpload(owner, openRecord, JPEG, SMALL_FILE));
+    }
+
+    @Test
+    void canUpload_ownerOfOwnClosedRecord_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canUpload(owner, closedRecord, JPEG, SMALL_FILE))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Bilagor kan inte laddas upp på stängda ärenden");
+    }
+
+    @Test
+    void canUpload_ownerOfOthersRecord_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canUpload(otherOwner, openRecord, JPEG, SMALL_FILE))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Du kan bara ladda upp bilagor på egna ärenden");
+    }
+
+    @Test
+    void canUpload_vetSameClinic_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() ->
+                policy.canUpload(vet, openRecord, JPEG, SMALL_FILE));
+    }
+
+    // VET får ladda upp även på ärenden vid annan klinik (remiss/konsultflöden).
+    @Test
+    void canUpload_vetOtherClinic_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() ->
+                policy.canUpload(vetOtherClinic, openRecord, JPEG, SMALL_FILE));
+    }
+
+    // VET utan klinik-koppling ska också kunna ladda upp (edge case).
+    @Test
+    void canUpload_vetWithoutClinic_shouldNotThrow() throws Exception {
+        User vetNoClinic = new User("Dr. Lös", "los@vet.se", "hash", Role.VET);
+        setPrivateField(vetNoClinic, "id", UUID.randomUUID());
+
+        assertThatNoException().isThrownBy(() ->
+                policy.canUpload(vetNoClinic, openRecord, JPEG, SMALL_FILE));
+    }
+
+    @Test
+    void canUpload_admin_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() ->
+                policy.canUpload(admin, openRecord, JPEG, SMALL_FILE));
+    }
+
+    // VET spärras nu på CLOSED (samma regel som OWNER).
+    @Test
+    void canUpload_vetOnClosedRecord_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canUpload(vet, closedRecord, JPEG, SMALL_FILE))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Bilagor kan inte laddas upp på stängda ärenden");
+    }
+
+    // ADMIN får fortsatt ladda upp på stängda ärenden (retroaktiv arkivering).
+    @Test
+    void canUpload_adminOnClosedRecord_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() ->
+                policy.canUpload(admin, closedRecord, JPEG, SMALL_FILE));
+    }
+
+    @Test
+    void canUpload_emptyFile_shouldThrowIllegalArgument() {
+        assertThatThrownBy(() -> policy.canUpload(vet, openRecord, JPEG, 0L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void canUpload_disallowedContentType_shouldThrowBusinessRule() {
+        assertThatThrownBy(() -> policy.canUpload(vet, openRecord, "application/zip", SMALL_FILE))
+                .isInstanceOf(BusinessRuleException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // canDelete
+    // -------------------------------------------------------------------------
+
+    @Test
+    void canDelete_owner_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canDelete(owner, attachmentUploadedByVet))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Djurägare får inte radera bilagor");
+    }
+
+    @Test
+    void canDelete_vetSameClinicOwnUpload_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() ->
+                policy.canDelete(vet, attachmentUploadedByVet));
+    }
+
+    @Test
+    void canDelete_vetSameClinicOthersUpload_shouldThrowForbidden() {
+        User otherVet = new User("Dr. Annan Klinik", "ak@vet.se", "hash", Role.VET, clinic);
+        try {
+            setPrivateField(otherVet, "id", UUID.randomUUID());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        assertThatThrownBy(() -> policy.canDelete(otherVet, attachmentUploadedByVet))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void canDelete_vetOtherClinic_shouldThrowForbidden() {
+        assertThatThrownBy(() -> policy.canDelete(vetOtherClinic, attachmentUploadedByVet))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Du har inte tillgång till ärenden på en annan klinik");
+    }
+
+    @Test
+    void canDelete_admin_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() ->
+                policy.canDelete(admin, attachmentUploadedByVet));
+    }
+
+    // -------------------------------------------------------------------------
+
+    private static void setPrivateField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/src/test/java/org/example/vet1177/policy/MedicalRecordPolicyTest.java
+++ b/src/test/java/org/example/vet1177/policy/MedicalRecordPolicyTest.java
@@ -106,14 +106,23 @@ class MedicalRecordPolicyTest {
     }
 
     // -------------------------------------------------------------------------
-    // canUpdate — OWNER blockerad helt; VET/ADMIN på samma klinik tillåtna
+    // canUpdate — OWNER får uppdatera eget öppet ärende (titel/beskrivning);
+    // status/close/assign-vet gatas separat
     // -------------------------------------------------------------------------
 
     @Test
-    void canUpdate_owner_shouldThrowForbidden() {
-        assertThatThrownBy(() -> policy.canUpdate(owner, openRecord))
+    void canUpdate_ownerOfOwnRecord_shouldNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.canUpdate(owner, openRecord));
+    }
+
+    @Test
+    void canUpdate_ownerOfOthersRecord_shouldThrowForbidden() throws Exception {
+        User otherOwner = new User("Bertil Annan", "b@mail.se", "hash", Role.OWNER);
+        setPrivateField(otherOwner, "id", UUID.randomUUID());
+
+        assertThatThrownBy(() -> policy.canUpdate(otherOwner, openRecord))
                 .isInstanceOf(ForbiddenException.class)
-                .hasMessage("Ägare får inte uppdatera journaler");
+                .hasMessage("Du kan bara uppdatera egna ärenden");
     }
 
     @Test
@@ -140,12 +149,22 @@ class MedicalRecordPolicyTest {
                 .hasMessage("Stängda ärenden kan inte uppdateras");
     }
 
-    // Auth-kontroll före isFinal-kontroll: en OWNER som ropar canUpdate på stängt ärende
-    // ska få 403 (ForbiddenException), inte 422 (BusinessRuleException).
+    // Auth-kontroll före isFinal-kontroll: OWNER på någon annans stängda ärende
+    // ska få 403 (ForbiddenException) på ägarskapskontrollen, inte 422.
     @Test
-    void canUpdate_ownerOnClosedRecord_shouldThrowForbiddenNotBusinessRule() {
-        assertThatThrownBy(() -> policy.canUpdate(owner, closedRecord))
+    void canUpdate_ownerOfOthersClosedRecord_shouldThrowForbiddenNotBusinessRule() throws Exception {
+        User otherOwner = new User("Bertil Annan", "b@mail.se", "hash", Role.OWNER);
+        setPrivateField(otherOwner, "id", UUID.randomUUID());
+
+        assertThatThrownBy(() -> policy.canUpdate(otherOwner, closedRecord))
                 .isInstanceOf(ForbiddenException.class);
+    }
+
+    // OWNER på eget stängt ärende passerar ägarskapskontrollen och faller på isFinal.
+    @Test
+    void canUpdate_ownerOfOwnClosedRecord_shouldThrowBusinessRule() {
+        assertThatThrownBy(() -> policy.canUpdate(owner, closedRecord))
+                .isInstanceOf(BusinessRuleException.class);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Öppnar upp AttachmentPolicy.canUpload så att VET alltid kan bifoga filer, oavsett kliniktillhörighet — t.ex. i remiss- och konsultflöden där remitterande 
  veterinär behöver komplettera ett ärende på en annan klinik. Samtidigt spärras VET på CLOSED-ärenden (samma regel som för OWNER) så att stängda journaler
  förblir oförändrade.                                                                                                                                      
                  
  Beteende                                                                                                                                                  
   
  ┌────────────────────┬──────────────┬───────────────┐                                                                                                     
  │        Roll        │ Öppet ärende │ Stängt ärende │
  ├────────────────────┼──────────────┼───────────────┤
  │ ADMIN                        │ ✅               │        ✅     │
  ├────────────────────┼──────────────┼───────────────┤
  │ VET (samma klinik) │ ✅           │ ❌ 403        │                                                                                                     ──
  ├────────────────────┼──────────────┼───────────────┤
  │ VET (annan klinik) │ ✅ (nytt)    │ ❌ 403        │                                                                                                       
  ├────────────────────┼──────────────┼───────────────┤                                                                                                     
  │ VET (ingen klinik) │ ✅ (nytt)    │ ❌ 403        │
  ├────────────────────┼──────────────┼───────────────┤                                                                                                     
  │ OWNER (eget)       │ ✅             │ ❌ 403        │
  ├────────────────────┼──────────────┼───────────────┤
  │ OWNER (annans)     │ ❌ 403       │ ❌ 403        │
  └────────────────────┴──────────────┴───────────────┘                                                                                                     
   
  Ändringar                                                                                                                                                 
                  
  AttachmentPolicy.canUpload
  - VET: klinikkontrollen borttagen
  - VET: ny CLOSED-spärr ("Bilagor kan inte laddas upp på stängda ärenden")                                                                                 
  - OWNER, ADMIN: oförändrade                                              
  - Kommentar ovan metoden motiverar remiss-/konsultflödet                                                                                                  
                  
  Oförändrat                                                                                                                                                
  - canDelete — VET kräver fortsatt samma klinik + egen uppladdning för att radera
  - SecurityConfig — POST /api/attachments/** faller redan igenom till authenticated()                                                                      
                                                                                      
  Tester                                                                                                                                                    
                                                                                                                                                            
  AttachmentPolicyTest
  - canUpload_vetOtherClinic_shouldThrowForbidden → canUpload_vetOtherClinic_shouldNotThrow                                                                 
  - canUpload_vetSameClinicOnClosedRecord_shouldNotThrow → canUpload_vetOnClosedRecord_shouldThrowForbidden                                                 
  - Ny: canUpload_vetWithoutClinic_shouldNotThrow                                                          
  - Ny: canUpload_adminOnClosedRecord_shouldNotThrow (tydliggör skillnaden mot VET)                                                                         
                                                                                                                                                            
  Test plan                                                                                                                                                 
                                                                                                                                                            
  - ./mvnw test — 500 gröna                                                                                                                                 
  - VET på annan klinik laddar upp på öppet ärende → 201
  - VET på stängt ärende → 403                                                                                                                              
  - ADMIN på stängt ärende → 201
  - OWNER- och canDelete-flöden oförändrade         

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Veterinarians can now upload attachments to medical records across clinics when records are open.
  * Record owners can now update their own open medical records.

* **Bug Fixes**
  * Enhanced enforcement of closed record restrictions to prevent unauthorized modifications to finalized medical records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->