### PR TITLE
fix: sort timeline ascending so newest message appears at bottom

### DIFF
--- a/frontend/src/pages/CaseDetail.jsx
+++ b/frontend/src/pages/CaseDetail.jsx
@@ -52,7 +52,7 @@ const CaseDetail = ({ caseData, onBack, onGoToPet, currentUserId, userRole }) =>
                 const combinedTimeline = [
                     ...commentsRes.data.map(c => ({ ...c, type: 'COMMENT' })),
                     ...logsRes.data.map(l => ({ ...l, type: 'ACTIVITY' }))
-                ].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+                ].sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
 
                 setTimeline(combinedTimeline);
                 setAttachments(attachRes.data);
@@ -71,7 +71,7 @@ const CaseDetail = ({ caseData, onBack, onGoToPet, currentUserId, userRole }) =>
             setTimeline(prev => [
                 ...prev.filter(i => i.type !== 'ACTIVITY'),
                 ...logsRes.data.map(l => ({ ...l, type: 'ACTIVITY' }))
-            ].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt)));
+            ].sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt)));
         } catch (error) {
             console.error("Kunde inte uppdatera aktivitetsloggen:", error);
         }
@@ -109,7 +109,7 @@ const CaseDetail = ({ caseData, onBack, onGoToPet, currentUserId, userRole }) =>
                 recordId: caseData.id,
                 body: newMessage
             });
-            setTimeline(prev => [...prev, { ...res.data, type: 'COMMENT' }].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt)));
+            setTimeline(prev => [...prev, { ...res.data, type: 'COMMENT' }].sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt)));
             setNewMessage('');
             await refetchActivityLog();
         } catch (error) {


### PR DESCRIPTION
Closes #246

## Vad är gjort
- Ändrat sorteringsordning i CaseDetail.jsx från fallande till stigande på tre ställen (rad 55, 74, 112)
- Meddelanden visas nu med nyaste längst ner, i enlighet med chattkonvention

## Ändring
`new Date(b.createdAt) - new Date(a.createdAt)` → `new Date(a.createdAt) - new Date(b.createdAt)`

## Ingen backend-ändring krävs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Timeline ordering in the case detail view has been adjusted. Comments and activity entries are now displayed in chronological order, showing the oldest entries first rather than the most recent entries at the top of the timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->