### PR TITLE
Bug fix/standardize status texts

### DIFF
--- a/frontend/src/components/admin/AuditLogView.jsx
+++ b/frontend/src/components/admin/AuditLogView.jsx
@@ -70,17 +70,6 @@ const AuditLogView = ({ logs = [], loading }) => {
         });
     }, [logs, searchTerm, actionFilter, roleFilter, clinicFilter, dateFilter]);
 
-                        {/* Content */}
-                        <div className="flex-1 pb-8">
-                            <div className="flex justify-between items-start mb-1">
-                                <h4 className="font-black text-slate-900 italic tracking-tight uppercase text-sm">
-                                    {getActionLabel(log.action)}
-                                </h4>
-                                <span className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
-                                    {date}
-                                </span>
-                            </div>
-                            <p className="text-slate-600 text-sm font-medium mb-2">{log.description}</p>
     if (loading) return <div className="p-20 text-center italic text-slate-400">Laddar administrativ historik...</div>;
 
     return (
@@ -161,7 +150,7 @@ const AuditLogView = ({ logs = [], loading }) => {
                                         <div className="flex justify-between items-start mb-1">
                                             <div className="flex items-center gap-3">
                                                 <h4 className="font-black text-slate-900 italic tracking-tight uppercase text-sm">
-                                                    {log.action.replace('_', ' ')}
+                                                    {getActionLabel(log.action)}
                                                 </h4>
                                                 <span className={`text-[9px] font-black px-2 py-0.5 rounded-md border ${
                                                     log.performedByRole?.includes('VET') ? 'bg-blue-50 text-blue-600 border-blue-100' :

--- a/frontend/src/components/admin/AuditLogView.jsx
+++ b/frontend/src/components/admin/AuditLogView.jsx
@@ -8,6 +8,7 @@ import {
     User as UserIcon,
     AlertCircle
 } from 'lucide-react';
+import { getActionLabel } from '../../utils/statusHelper';
 
 const AuditLogView = ({ logs = [], loading }) => {
 
@@ -52,7 +53,7 @@ const AuditLogView = ({ logs = [], loading }) => {
                         <div className="flex-1 pb-8">
                             <div className="flex justify-between items-start mb-1">
                                 <h4 className="font-black text-slate-900 italic tracking-tight uppercase text-sm">
-                                    {log.action.replace('_', ' ')}
+                                    {getActionLabel(log.action)}
                                 </h4>
                                 <span className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
                                     {date}

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -172,7 +172,7 @@ const AdminDashboard = ({ userName, initialTab = 'USERS' }) => {
                         <div className="flex items-center gap-4">
                             <div className="bg-red-50 p-3 rounded-2xl text-red-600"><ShieldAlert size={24} /></div>
                             <div>
-                                <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">Admininstratörer</p>
+                                <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest">Administratörer</p>
                                 <p className="text-3xl font-black text-slate-900">{stats.admins}</p>
                             </div>
                         </div>
@@ -208,7 +208,7 @@ const AdminDashboard = ({ userName, initialTab = 'USERS' }) => {
                                     activeTab === 'LOGS' ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-400'
                                 }`}
                             >
-                                Audit Log
+                                Aktivitetslogg
                             </button>
                         </div>
 

--- a/frontend/src/pages/CaseDetail.jsx
+++ b/frontend/src/pages/CaseDetail.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { commentService, activityService, attachmentService, medicalRecordService } from '../services/api';
-import { STATUS_MAP } from '../utils/statusHelper';
+import { STATUS_MAP, ACTIVE_STATUS_KEYS } from '../utils/statusHelper';
 import { Stethoscope, Lock, FileText, CheckCircle, Upload, Trash2, ExternalLink } from 'lucide-react';
 
 const CaseDetail = ({ caseData, onBack, onGoToPet, currentUserId, userRole }) => {
@@ -206,9 +206,9 @@ const CaseDetail = ({ caseData, onBack, onGoToPet, currentUserId, userRole }) =>
                                     onChange={(e) => handleStatusChange(e.target.value)}
                                     className="bg-slate-800 border border-slate-700 text-sm font-bold rounded-xl px-4 py-2 outline-none focus:ring-2 focus:ring-vet-accent transition-all cursor-pointer"
                                 >
-                                    <option value="OPEN">Öppen</option>
-                                    <option value="IN_PROGRESS">Under behandling</option>
-                                    <option value="AWAITING_INFO">Väntar på svar</option>
+                                    {ACTIVE_STATUS_KEYS.map((key) => (
+                                        <option key={key} value={key}>{STATUS_MAP[key].label}</option>
+                                    ))}
                                 </select>
                             </div>
                             <button

--- a/frontend/src/pages/CaseDetail.jsx
+++ b/frontend/src/pages/CaseDetail.jsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { commentService, activityService, attachmentService, medicalRecordService } from '../services/api';
 import { STATUS_MAP, ACTIVE_STATUS_KEYS } from '../utils/statusHelper';
-import { Stethoscope, Lock, FileText, CheckCircle, Upload, Trash2, ExternalLink } from 'lucide-react';
-import { STATUS_MAP } from '../utils/statusHelper';
 import { Stethoscope, Lock, FileText, CheckCircle, Upload, Trash2, ExternalLink, UserMinus } from 'lucide-react';
 
 const CaseDetail = ({ caseData, onBack, onGoToPet, currentUserId, userRole, onDirtyChange }) => {

--- a/frontend/src/utils/statusHelper.js
+++ b/frontend/src/utils/statusHelper.js
@@ -1,7 +1,33 @@
 // src/utils/statusHelper.js
+//
+// Gemensam mappning från backend-enum till svenska visningstexter.
+// Används överallt där status eller aktivitetsloggar visas i UI:t så att
+// texterna förblir konsekventa. Motsvarighet finns i backend
+// (RecordStatus.displayLabel()) för loggrader som skrivs till databasen.
+
 export const STATUS_MAP = {
-    'OPEN': { label: 'Inskickat', color: 'bg-blue-50 text-blue-700 border-blue-100' },
-    'IN_PROGRESS': { label: 'Under behandling', color: 'bg-yellow-50 text-yellow-700 border-yellow-100' },
-    'AWAITING_INFO': { label: 'Väntar på svar', color: 'bg-purple-50 text-purple-700 border-purple-100' },
-    'CLOSED': { label: 'Avslutat', color: 'bg-slate-50 text-slate-500 border-slate-100' }
+    'OPEN':          { label: 'Öppen',            color: 'bg-blue-50 text-blue-700 border-blue-100' },
+    'IN_PROGRESS':   { label: 'Under behandling', color: 'bg-yellow-50 text-yellow-700 border-yellow-100' },
+    'AWAITING_INFO': { label: 'Väntar på svar',   color: 'bg-purple-50 text-purple-700 border-purple-100' },
+    'CLOSED':        { label: 'Avslutad',         color: 'bg-slate-50 text-slate-500 border-slate-100' }
 };
+
+// Statusar som VET kan välja i dropdown. CLOSED utesluts — stängning sker
+// via "Slutför & Stäng"-modalen för att tvinga fram en slutnotering.
+export const ACTIVE_STATUS_KEYS = ['OPEN', 'IN_PROGRESS', 'AWAITING_INFO'];
+
+// Svensk label för en status, med fallback till raw-värdet om enum-värdet
+// inte känns igen (t.ex. nytt värde tillagt i backend men inte här).
+export const getStatusLabel = (status) => STATUS_MAP[status]?.label ?? status;
+
+// Mappning för ActivityType-enum → svensk rubrik.
+// Används av AuditLogView i admin-vyn där log.action visas direkt.
+export const ACTION_LABELS = {
+    'CASE_CREATED':   'Ärende skapat',
+    'STATUS_CHANGED': 'Status ändrad',
+    'COMMENT_ADDED':  'Kommentar tillagd',
+    'ASSIGNED':       'Veterinär tilldelad',
+    'UPDATED':        'Ärende uppdaterat'
+};
+
+export const getActionLabel = (action) => ACTION_LABELS[action] ?? action;

--- a/frontend/src/utils/statusHelper.js
+++ b/frontend/src/utils/statusHelper.js
@@ -27,6 +27,7 @@ export const ACTION_LABELS = {
     'STATUS_CHANGED': 'Status ändrad',
     'COMMENT_ADDED':  'Kommentar tillagd',
     'ASSIGNED':       'Veterinär tilldelad',
+    'UNASSIGNED':     'Ärende släppt',
     'UPDATED':        'Ärende uppdaterat'
 };
 

--- a/src/main/java/org/example/vet1177/entities/RecordStatus.java
+++ b/src/main/java/org/example/vet1177/entities/RecordStatus.java
@@ -1,7 +1,23 @@
 package org.example.vet1177.entities;
 
 public enum RecordStatus {
-    OPEN, IN_PROGRESS, AWAITING_INFO, CLOSED;
+    OPEN("Öppen"),
+    IN_PROGRESS("Under behandling"),
+    AWAITING_INFO("Väntar på svar"),
+    CLOSED("Avslutad");
+
+    private final String displayLabel;
+
+    RecordStatus(String displayLabel) {
+        this.displayLabel = displayLabel;
+    }
+
+    // Svensk visningstext. Används i serverskrivna aktivitetsloggar så att
+    // loggraderna i activity_log lagras på samma språk som övriga beskrivningar.
+    // Frontend har motsvarande STATUS_MAP i statusHelper.js.
+    public String displayLabel() {
+        return displayLabel;
+    }
 
     public boolean isFinal() {
         return this == CLOSED;

--- a/src/main/java/org/example/vet1177/services/MedicalRecordService.java
+++ b/src/main/java/org/example/vet1177/services/MedicalRecordService.java
@@ -219,10 +219,10 @@ public class MedicalRecordService {
 
         MedicalRecord updated = medicalRecordRepository.save(record);
 
-        // LOGGING
+        // LOGGING — använd svensk label så loggen matchar UI-texterna.
         activityLogService.log(
                 ActivityType.STATUS_CHANGED,
-                "Status ändrad till: " + newStatus,
+                "Status ändrad till: " + newStatus.displayLabel(),
                 updatedBy,
                 updated
         );

--- a/src/test/java/org/example/vet1177/services/MedicalRecordServiceTest.java
+++ b/src/test/java/org/example/vet1177/services/MedicalRecordServiceTest.java
@@ -360,7 +360,7 @@ class MedicalRecordServiceTest {
 
         verify(activityLogService).log(
                 eq(ActivityType.STATUS_CHANGED),
-                contains("AWAITING_INFO"),
+                contains(RecordStatus.AWAITING_INFO.displayLabel()),
                 eq(currentUser),
                 eq(record));
     }


### PR DESCRIPTION
Standardiserar statustexter över hela gränssnittet och fixar två mindre textbuggar i admin-vyn. Tidigare visade ärendetiteln, status-dropdownen och        
  aktivitetsloggen olika ord för samma status (Inskickat / Öppen / IN_PROGRESS). Nu kommer alla texter från en enda mappning både i frontend och backend.
                                                                                                                                                             
  Ändringar       

  Statustexter — ny master-mappning                                                                                                                                                                                                                                       
   
  Backend                                                                                                                                                    
  - RecordStatus.java: enumet har nu en displayLabel()-metod med svenska texter. Används av MedicalRecordService.updateStatus när status-ändringar loggas
  till activity_log-tabellen, så att lograderna lagras på svenska istället för raw enum.                                                                     
  - MedicalRecordService.java: "Status ändrad till: " + newStatus → "Status ändrad till: " + newStatus.displayLabel().
  - MedicalRecordServiceTest.updateStatus_shouldLogActivity: uppdaterat så testet kopplas till labeln istället för enum-namnet.                              
                                                                                                                                                             
  Frontend                                                                                                                                                   
  - statusHelper.js:                                                                                                                                         
    - OPEN-label: Inskickat → Öppen                                                                                                                          
    - CLOSED-label: Avslutat → Avslutad
    - Ny ACTIVE_STATUS_KEYS (statusar VET kan välja i dropdown — CLOSED utesluts, stängs via modalen)                                                        
    - Ny getStatusLabel() med fallback                                                               
    - Ny ACTION_LABELS + getActionLabel() för ActivityType-enum                                                                                              
  - CaseDetail.jsx: hårdkodade <option>-rader i status-dropdownen ersatta av loop över ACTIVE_STATUS_KEYS. Dropdown och header-badge kan inte längre gå ur
  synk.                                                                                                                                                      
  - AuditLogView.jsx: log.action.replace('_', ' ') → getActionLabel(log.action). Admin ser nu svenska rubriker: "Ärende skapat", "Status ändrad", "Kommentar 
  tillagd", "Veterinär tilldelad", "Ärende uppdaterat" istället för STATUS CHANGED m.fl.                                                                     
                                                                                                                                                             
  Övriga UI-textfixar
                                                                                                                                                             
  AdminDashboard.jsx
  - Rad 175: stavfel Admininstratörer → Administratörer                                                                                                      
  - Rad 211: Audit Log → Aktivitetslogg (enda engelska UI-strängen i hela appen)                                                                             
                                                                                
  Påverkan på användaren                                                                                                                                     
                                                                                                                                                             
  - CaseDetail header-badge, dashboards, PetDetail-lista, VET-dropdown: samma statustext överallt ("Öppen" / "Under behandling" / "Väntar på svar" /         
  "Avslutad").                                                                                                                                               
  - CaseDetail "Logg & Historik": status-ändringsraden visar "Status ändrad till: Under behandling" istället för "...IN_PROGRESS".                           
  - Admin-vyn: svenska rubriker på varje logghändelse.                                                                                                       
  - Historiska rader i activity_log med gamla enum-texter förblir oförändrade. Fixen gäller nya rader.  

closes #239 
closes #249 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected typo in admin dashboard label
  * Audit logs now show human-readable Swedish action labels

* **New Features**
  * Audit log view displays formatted action heading, date, and description
  * Status selector now built dynamically from available statuses

* **Localization**
  * Swedish display labels updated for status values and audit/dashboard terminology
<!-- end of auto-generated comment: release notes by coderabbit.ai -->