### PR TITLE
Fix/vet to un assign from case

### DIFF
--- a/frontend/src/pages/CaseDetail.jsx
+++ b/frontend/src/pages/CaseDetail.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { commentService, activityService, attachmentService, medicalRecordService } from '../services/api';
 import { STATUS_MAP } from '../utils/statusHelper';
-import { Stethoscope, Lock, FileText, CheckCircle, Upload, Trash2, ExternalLink } from 'lucide-react';
+import { Stethoscope, Lock, FileText, CheckCircle, Upload, Trash2, ExternalLink, UserMinus } from 'lucide-react';
 
 const CaseDetail = ({ caseData, onBack, onGoToPet, currentUserId, userRole }) => {
     const [newMessage, setNewMessage] = useState('');
@@ -84,6 +84,17 @@ const CaseDetail = ({ caseData, onBack, onGoToPet, currentUserId, userRole }) =>
             await refetchActivityLog();
         } catch (error) {
             alert("Kunde inte uppdatera status.");
+        }
+    };
+
+    const handleReleaseCase = async () => {
+        if (!window.confirm("Släppa ärendet? Det blir ledigt för en annan veterinär att ta över.")) return;
+        try {
+            const res = await medicalRecordService.unassignVet(caseData.id);
+            if (res?.data?.status) setLocalStatus(res.data.status);
+            await refetchActivityLog();
+        } catch (error) {
+            alert("Kunde inte släppa ärendet.");
         }
     };
 
@@ -211,6 +222,14 @@ const CaseDetail = ({ caseData, onBack, onGoToPet, currentUserId, userRole }) =>
                                     <option value="AWAITING_INFO">Väntar på svar</option>
                                 </select>
                             </div>
+                            {caseData.assignedVetId === currentUserId && (
+                                <button
+                                    onClick={handleReleaseCase}
+                                    className="bg-slate-700 hover:bg-slate-600 text-white px-6 py-3 rounded-xl text-xs font-black uppercase tracking-widest transition-all shadow-lg flex items-center gap-2 self-end"
+                                >
+                                    <UserMinus size={14} /> Släpp ärende
+                                </button>
+                            )}
                             <button
                                 onClick={() => setShowCloseModal(true)}
                                 className="bg-red-500 hover:bg-red-600 text-white px-6 py-3 rounded-xl text-xs font-black uppercase tracking-widest transition-all shadow-lg shadow-red-500/20 flex items-center gap-2 self-end"

--- a/frontend/src/services/api.jsx
+++ b/frontend/src/services/api.jsx
@@ -85,6 +85,7 @@ export const medicalRecordService = {
 
     // Arbetsflöde (Veterinär)
     assignVet: (id, vetId) => api.put(`/medical-records/${id}/assign-vet`, { vetId }),
+    unassignVet: (id) => api.put(`/medical-records/${id}/unassign-vet`),
     updateStatus: (id, status) => api.put(`/medical-records/${id}/status`, { status }),
     closeRecord: (id) => api.put(`/medical-records/${id}/close`),
     getMyAssignedRecords: () => api.get('/medical-records/my-assigned'),

--- a/src/main/java/org/example/vet1177/controller/MedicalRecordController.java
+++ b/src/main/java/org/example/vet1177/controller/MedicalRecordController.java
@@ -228,6 +228,24 @@ public class MedicalRecordController {
         );
     }
 
+    // PUT /api/medical-records/{id}/unassign-vet
+    @PutMapping("/{id}/unassign-vet")
+    @Transactional
+    public ResponseEntity<MedicalRecordResponse> unassignVet(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal User currentUser) {
+
+        log.info("PUT /api/medical-records/{}/unassign-vet", id);
+        MedicalRecord record = medicalRecordService.getById(id);
+        medicalRecordPolicy.canUnassignVet(currentUser, record);
+
+        return ResponseEntity.ok(
+                MedicalRecordResponse.from(
+                        medicalRecordService.unassignVet(id, currentUser)
+                )
+        );
+    }
+
     // PUT /api/medical-records/{id}/status
     @PutMapping("/{id}/status")
     @Transactional

--- a/src/main/java/org/example/vet1177/entities/ActivityType.java
+++ b/src/main/java/org/example/vet1177/entities/ActivityType.java
@@ -5,5 +5,6 @@ public enum ActivityType {
     STATUS_CHANGED,
     COMMENT_ADDED,
     ASSIGNED,
+    UNASSIGNED,
     UPDATED
 }

--- a/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
+++ b/src/main/java/org/example/vet1177/policy/MedicalRecordPolicy.java
@@ -99,6 +99,24 @@ public class MedicalRecordPolicy {
         }
     }
 
+    // Endast den tilldelade VET:en själv (eller ADMIN) får släppa ärendet.
+    // Kollegor på samma klinik spärras — principen är "man äger sitt eget arbete".
+    public void canUnassignVet(User user, MedicalRecord record) {
+        switch (user.getRole()) {
+            case OWNER ->
+                    throw new ForbiddenException("Ägare får inte släppa ärenden");
+            case VET -> {
+                if (record.getAssignedVet() == null ||
+                        !record.getAssignedVet().getId().equals(user.getId()))
+                    throw new ForbiddenException("Du kan bara släppa ärenden du själv är tilldelad");
+            }
+            case ADMIN -> {}
+        }
+
+        if (record.getStatus().isFinal())
+            throw new BusinessRuleException("Stängda ärenden kan inte ändras");
+    }
+
     public void canClose(User user, MedicalRecord record) {
         switch (user.getRole()) {
             case OWNER ->

--- a/src/main/java/org/example/vet1177/security/SecurityConfig.java
+++ b/src/main/java/org/example/vet1177/security/SecurityConfig.java
@@ -98,6 +98,7 @@ public class SecurityConfig {
                         // /status, /close, /assign-vet förblir VET/ADMIN-only på URL-nivå.
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/close").hasAnyRole("VET", "ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/assign-vet").hasAnyRole("VET", "ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/unassign-vet").hasAnyRole("VET", "ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/medical-records/*/status").hasAnyRole("VET", "ADMIN")
 
                         // ─── VET/ADMIN: klinik-vy ───

--- a/src/main/java/org/example/vet1177/services/MedicalRecordService.java
+++ b/src/main/java/org/example/vet1177/services/MedicalRecordService.java
@@ -202,6 +202,37 @@ public class MedicalRecordService {
 
     }
 
+    // Släpper nuvarande handläggare från ärendet. Återställer status till OPEN om
+    // ärendet var IN_PROGRESS (speglar assignVet som satte IN_PROGRESS); andra statusar
+    // som VET manuellt satt (t.ex. AWAITING_INFO) bevaras.
+    public MedicalRecord unassignVet(UUID recordId, User updatedBy) {
+        log.info("Unassigning vet from record id={}", recordId);
+        MedicalRecord record = getById(recordId);
+
+        if (record.getAssignedVet() == null) {
+            throw new BusinessRuleException("Ärendet har ingen tilldelad handläggare");
+        }
+
+        User releasedVet = record.getAssignedVet();
+
+        record.setAssignedVet(null);
+        if (record.getStatus() == RecordStatus.IN_PROGRESS) {
+            record.setStatus(RecordStatus.OPEN);
+        }
+        record.setUpdatedBy(updatedBy);
+
+        MedicalRecord updated = medicalRecordRepository.save(record);
+
+        activityLogService.log(
+                ActivityType.UNASSIGNED,
+                "Veterinär " + releasedVet.getName() + " har släppt ärendet",
+                updatedBy,
+                updated
+        );
+
+        return updated;
+    }
+
     public MedicalRecord updateStatus(UUID recordId, RecordStatus newStatus, User updatedBy) {
         log.info("Updating status of record id={} to {}", recordId, newStatus);
         MedicalRecord record = getById(recordId);

--- a/src/test/java/org/example/vet1177/policy/MedicalRecordPolicyTest.java
+++ b/src/test/java/org/example/vet1177/policy/MedicalRecordPolicyTest.java
@@ -224,6 +224,61 @@ class MedicalRecordPolicyTest {
     }
 
     // -------------------------------------------------------------------------
+    // canUnassignVet — endast den tilldelade veterinären själv (+ ADMIN)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void canUnassignVet_owner_shouldThrowForbidden() {
+        openRecord.setAssignedVet(vet);
+        assertThatThrownBy(() -> policy.canUnassignVet(owner, openRecord))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Ägare får inte släppa ärenden");
+    }
+
+    @Test
+    void canUnassignVet_vetSelf_shouldNotThrow() {
+        openRecord.setAssignedVet(vet);
+        assertThatNoException().isThrownBy(() -> policy.canUnassignVet(vet, openRecord));
+    }
+
+    @Test
+    void canUnassignVet_vetColleagueSameClinic_shouldThrowForbidden() throws Exception {
+        openRecord.setAssignedVet(vet);
+        User colleagueVet = new User("Dr. Kollega", "kollega@vet.se", "hash", Role.VET, clinic);
+        setPrivateField(colleagueVet, "id", UUID.randomUUID());
+
+        assertThatThrownBy(() -> policy.canUnassignVet(colleagueVet, openRecord))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Du kan bara släppa ärenden du själv är tilldelad");
+    }
+
+    @Test
+    void canUnassignVet_vetOnRecordWithoutAssignee_shouldThrowForbidden() {
+        openRecord.setAssignedVet(null);
+        assertThatThrownBy(() -> policy.canUnassignVet(vet, openRecord))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void canUnassignVet_admin_shouldNotThrow() {
+        openRecord.setAssignedVet(vet);
+        assertThatNoException().isThrownBy(() -> policy.canUnassignVet(admin, openRecord));
+    }
+
+    @Test
+    void canUnassignVet_adminOnRecordWithoutAssignee_shouldNotThrow() {
+        openRecord.setAssignedVet(null);
+        assertThatNoException().isThrownBy(() -> policy.canUnassignVet(admin, openRecord));
+    }
+
+    @Test
+    void canUnassignVet_closedRecord_shouldThrowBusinessRule() {
+        closedRecord.setAssignedVet(vet);
+        assertThatThrownBy(() -> policy.canUnassignVet(vet, closedRecord))
+                .isInstanceOf(BusinessRuleException.class);
+    }
+
+    // -------------------------------------------------------------------------
     // canViewClinic — OWNER blockeras, VET på rätt klinik släpps, ADMIN alltid
     // -------------------------------------------------------------------------
 

--- a/src/test/java/org/example/vet1177/services/MedicalRecordServiceTest.java
+++ b/src/test/java/org/example/vet1177/services/MedicalRecordServiceTest.java
@@ -328,6 +328,77 @@ class MedicalRecordServiceTest {
     }
 
     // -------------------------------------------------------------------------
+    // unassignVet
+    // -------------------------------------------------------------------------
+
+    @Test
+    void unassignVet_shouldClearAssignedVetAndReturn() {
+        User vet = new User("Dr. Erik", "erik@vet.se", "hash", Role.VET);
+        record.setAssignedVet(vet);
+        record.setStatus(RecordStatus.IN_PROGRESS);
+        when(medicalRecordRepository.findById(recordId)).thenReturn(Optional.of(record));
+        when(medicalRecordRepository.save(record)).thenReturn(record);
+
+        MedicalRecord result = medicalRecordService.unassignVet(recordId, currentUser);
+
+        assertThat(result.getAssignedVet()).isNull();
+    }
+
+    @Test
+    void unassignVet_whenStatusInProgress_shouldResetToOpen() {
+        User vet = new User("Dr. Erik", "erik@vet.se", "hash", Role.VET);
+        record.setAssignedVet(vet);
+        record.setStatus(RecordStatus.IN_PROGRESS);
+        when(medicalRecordRepository.findById(recordId)).thenReturn(Optional.of(record));
+        when(medicalRecordRepository.save(record)).thenReturn(record);
+
+        MedicalRecord result = medicalRecordService.unassignVet(recordId, currentUser);
+
+        assertThat(result.getStatus()).isEqualTo(RecordStatus.OPEN);
+    }
+
+    @Test
+    void unassignVet_whenStatusAwaitingInfo_shouldKeepStatus() {
+        User vet = new User("Dr. Erik", "erik@vet.se", "hash", Role.VET);
+        record.setAssignedVet(vet);
+        record.setStatus(RecordStatus.AWAITING_INFO);
+        when(medicalRecordRepository.findById(recordId)).thenReturn(Optional.of(record));
+        when(medicalRecordRepository.save(record)).thenReturn(record);
+
+        MedicalRecord result = medicalRecordService.unassignVet(recordId, currentUser);
+
+        assertThat(result.getStatus()).isEqualTo(RecordStatus.AWAITING_INFO);
+    }
+
+    @Test
+    void unassignVet_shouldLogActivityWithVetName() {
+        User vet = new User("Dr. Erik Vet", "erik@vet.se", "hash", Role.VET);
+        record.setAssignedVet(vet);
+        when(medicalRecordRepository.findById(recordId)).thenReturn(Optional.of(record));
+        when(medicalRecordRepository.save(record)).thenReturn(record);
+
+        medicalRecordService.unassignVet(recordId, currentUser);
+
+        verify(activityLogService).log(
+                eq(ActivityType.UNASSIGNED),
+                eq("Veterinär Dr. Erik Vet har släppt ärendet"),
+                eq(currentUser),
+                eq(record));
+    }
+
+    @Test
+    void unassignVet_whenNoAssignedVet_shouldThrowBusinessRuleException() {
+        record.setAssignedVet(null);
+        when(medicalRecordRepository.findById(recordId)).thenReturn(Optional.of(record));
+
+        assertThatThrownBy(() -> medicalRecordService.unassignVet(recordId, currentUser))
+                .isInstanceOf(BusinessRuleException.class)
+                .hasMessage("Ärendet har ingen tilldelad handläggare");
+
+        verify(medicalRecordRepository, never()).save(any());
+    }
+
+    // -------------------------------------------------------------------------
     // updateStatus
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
 Tillåter VET att släppa ärenden hen själv är tilldelad, så att ärendet blir ledigt för en kollega att ta över. 
   "bara den assignade VET:en + ADMIN får un-assigna, kollegor på samma klinik ska inte kunna rycka ärenden från varandra".
                                                                                                                                                             
  Beteende                                                  

  VET kan:
  - Släppa ett ärende hen är tilldelad (knapp visas bara då)
                                                                                                                                                             
  VET kan inte:
  - Släppa ärenden hen inte är tilldelad (knapp döljs i UI + 403 från policy om endpoint anropas direkt)                                                     
  - Släppa stängda ärenden (422)                                                                                                                             
                                                                                                                                                             
  ADMIN kan: släppa vilket ärende som helst.                                                                                                                 
                                                            
  OWNER: 403 (oförändrat).                                                                                                                                   
                                                            
  Statuspåverkan                                                                                                                                             
                                                            
  Speglar assignVet-logiken som sätter IN_PROGRESS:                                                                                                          
  - Status IN_PROGRESS → OPEN (ärendet blir ledigt igen)    
  - Status AWAITING_INFO eller annan VET-satt status → bevaras                                                                                               
  - Status CLOSED → endpoint kastar 422                       
                                                                                                                                                             
  Ändringar                                                                                                                                                  
                                                                                                                                                             
  Backend                                                                                                                                                    
  - ActivityType.java — nytt enum-värde UNASSIGNED          
  - MedicalRecordPolicy.java — ny canUnassignVet(user, record): OWNER 403, VET endast om record.getAssignedVet().id == user.id, ADMIN ok, CLOSED kastar
  BusinessRuleException                                                                                                                                
  - MedicalRecordService.java — ny unassignVet(recordId, updatedBy): kastar 422 om ingen handläggare finns, sätter assignedVet = null, återställer           
  IN_PROGRESS → OPEN, loggar "Veterinär {namn} har släppt ärendet"                                                                                
  - MedicalRecordController.java — ny endpoint PUT /api/medical-records/{id}/unassign-vet (ingen body)                                                       
  - SecurityConfig.java — URL-regel PUT /api/medical-records/*/unassign-vet → hasAnyRole("VET", "ADMIN")
                                                                                                                                                             
  Backend-tester (12 nya)                                   
  - MedicalRecordPolicyTest: owner/vet-self/vet-colleague/vet-without-assignee/admin/admin-no-assignee/closed                                                
  - MedicalRecordServiceTest: clear-assigned-vet, status-reset-from-IN_PROGRESS, status-preserved-from-AWAITING_INFO, exakt loggtext med vet-namn,           
  already-unassigned-throws                                                                                                                                  
                                                                                                                                                             
  Frontend                                                  
  - api.jsx — ny unassignVet(id)                                                                                                                             
  - CaseDetail.jsx:                                                                                                                                          
    - Ny handleReleaseCase med window.confirm, uppdaterar lokal status och refetchar activity log
    - Ny "Släpp ärende"-knapp (UserMinus-ikon) i VET-panelen, bredvid "Stäng Journal"                                                                        
    - Villkorlig rendering: knappen visas endast om caseData.assignedVetId === currentUserId                                                                 
    - UserMinus importerad från lucide-react                                                                                                                 
                                                                                                                                                             
  Test plan                                                                                                                                                  
                                                                                                                                                             
  - ./mvnw test — 512/512 gröna                                                                                                                              
  - VET öppnar eget tilldelat ärende → "Släpp ärende"-knapp syns bredvid "Stäng Journal"
  - VET öppnar kollegans tilldelade ärende → knappen syns inte                                                                                               
  - VET klickar "Släpp ärende" → confirm → efter bekräftelse: assignedVet rensas, status återgår till "Öppen" (om den var IN_PROGRESS), loggen visar         
  "Veterinär [namn] har släppt ärendet"                                                                                                                      
  - VET försöker släppa ett otilldelat ärende via direkt API-anrop → 403                                                                                     
  - VET försöker släppa ett stängt ärende → 422                                                                                                              
  - OWNER försöker släppa via direkt API-anrop → 403                                                                                                         
  - ADMIN kan släppa vilket tilldelat ärende som helst
Closes #243 
